### PR TITLE
Updated to the latest node versions to eliminate dependency errors

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/package.json
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/package.json
@@ -1,16 +1,17 @@
 {
-  "name": "foundation-libsass-template",
-  "version": "0.0.1",
-  "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-uglify": "^0.8.1",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-grunticon": "^2.1.2",
-    "grunt-sass": "~0.17.0",
-    "grunt-svgmin": "^2.0.0",
-    "node-sass": "~1.2.3"
-  },
-  "scripts": {
-    "postinstall": "sh npm_post.sh"
-  }
+ "name": "foundation-libsass-template",
+ "version": "0.0.1",
+ "devDependencies": {
+   "grunt": "^0.4.5",
+   "grunt-contrib-uglify": "^0.8.1",
+   "grunt-contrib-watch": "^0.6.1",
+   "grunt-grunticon": "^2.1.2",
+   "grunt-sass": "^1.0.0",
+   "grunt-svgmin": "^2.0.0",
+   "load-grunt-tasks": "^3.2.0",
+   "node-sass": "^3.2.0"
+ },
+ "scripts": {
+   "postinstall": "sh npm_post.sh"
+ }
 }


### PR DESCRIPTION
This update requires that the developer be on the latest version of node and npm.