### PR TITLE
Went back and forth on some stuff

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,19 +42,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # you can modify these manually if you want specific specs
     v.customize ["modifyvm", :id, "--memory", mem]
     v.customize ["modifyvm", :id, "--cpus", cpus]
-
   end
-
-
+  
   # run script as root
   config.vm.provision "shell",
     path: "scripts/vagrant/handsfree-vagrant.sh"
-  # run inline script as root
 
-#remove the error sudo: sorry, you must have a tty to run sudo
-#see //github.com/mitchellh/vagrant-rackspace#centos--rhel--fedora
-  config.vm.provision "shell",
-    inline: "sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers"
+  # run inline script as root
+  #remove the error sudo: sorry, you must have a tty to run sudo
+  #see //github.com/mitchellh/vagrant-rackspace#centos--rhel--fedora
+    config.vm.provision "shell",
+      inline: "sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers"
 
   # run as the vagrant user
   config.vm.provision "shell",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,35 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network "forwarded_port", guest: 80, host: 80
   config.vm.network "forwarded_port", guest: 3306, host: 3306
 
+  # automatically carve out 1/4 of the box resources for this VM
+  config.vm.provider "virtualbox" do |v|
+    host = RbConfig::CONFIG['host_os']
+
+    # Give VM 1/4 system memory & access to all cpu cores on the host
+    if host =~ /darwin/
+      cpus = `sysctl -n hw.ncpu`.to_i
+      # sysctl returns Bytes and we need to convert to MB
+      mem = `sysctl -n hw.memsize`.to_i / 1024 / 1024 / 4
+    elsif host =~ /linux/
+      cpus = `nproc`.to_i
+      # meminfo shows KB and we need to convert to MB
+      mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024 / 4
+    elsif host =~ /mingw32/
+      mem = `wmic os get TotalVisibleMemorySize | grep '^[0-9]'`.to_i / 1024 / 4
+      if mem < 1024
+        mem = 1024
+      end
+      cpus = 2
+    else # sorry weird Windows folks, I can't help you
+      cpus = 2
+      mem = 1024
+    end
+    # you can modify these manually if you want specific specs
+    v.customize ["modifyvm", :id, "--memory", mem]
+    v.customize ["modifyvm", :id, "--cpus", cpus]
+
+  end
+
 
   # run script as root
   config.vm.provision "shell",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,40 +9,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #config.vm.box = "chef/centos-6.5-i386"
 
   # centos 6.5 - 64 bit
-  config.vm.box = "chef/centos-6.5"
+  config.vm.box = "puphpet/centos65-x64"
   # private network port maping, host files point to elmsln domains
   config.vm.network "private_network", ip: "10.0.18.55"
   # forward the vm ports for database and apache to local ones
   config.vm.network "forwarded_port", guest: 80, host: 80
   config.vm.network "forwarded_port", guest: 3306, host: 3306
 
-  # automatically carve out 1/4 of the box resources for this VM
-  config.vm.provider "virtualbox" do |v|
-    host = RbConfig::CONFIG['host_os']
-
-    # Give VM 1/4 system memory & access to all cpu cores on the host
-    if host =~ /darwin/
-      cpus = `sysctl -n hw.ncpu`.to_i
-      # sysctl returns Bytes and we need to convert to MB
-      mem = `sysctl -n hw.memsize`.to_i / 1024 / 1024 / 4
-    elsif host =~ /linux/
-      cpus = `nproc`.to_i
-      # meminfo shows KB and we need to convert to MB
-      mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024 / 4
-    elsif host =~ /mingw32/
-      mem = `wmic os get TotalVisibleMemorySize | grep '^[0-9]'`.to_i / 1024 / 4
-      if mem < 1024
-        mem = 1024
-      end
-      cpus = 2
-    else # sorry weird Windows folks, I can't help you
-      cpus = 2
-      mem = 1024
-    end
-    # you can modify these manually if you want specific specs
-    v.customize ["modifyvm", :id, "--memory", mem]
-    v.customize ["modifyvm", :id, "--cpus", cpus]
-  end
 
   # run script as root
   config.vm.provision "shell",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,6 +49,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # run script as root
   config.vm.provision "shell",
     path: "scripts/vagrant/handsfree-vagrant.sh"
+  # run inline script as root
+
+#remove the error sudo: sorry, you must have a tty to run sudo
+#see //github.com/mitchellh/vagrant-rackspace#centos--rhel--fedora
+  config.vm.provision "shell",
+    inline: "sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers"
 
   # run as the vagrant user
   config.vm.provision "shell",

--- a/scripts/install/handsfree/centos/centos-install.sh
+++ b/scripts/install/handsfree/centos/centos-install.sh
@@ -47,6 +47,11 @@ cat /var/www/elmsln/docs/varnish.txt > /etc/varnish/default.vcl
 service varnish start
 chkconfig varnish on
 
+#remove the error sudo: sorry, you must have a tty to run sudo
+#see //github.com/mitchellh/vagrant-rackspace#centos--rhel--fedora
+sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
+
+
 # make an admin group
 groupadd admin
 # run the handsfree installer that's the same for all deployments

--- a/scripts/install/handsfree/centos/centos-install.sh
+++ b/scripts/install/handsfree/centos/centos-install.sh
@@ -47,11 +47,6 @@ cat /var/www/elmsln/docs/varnish.txt > /etc/varnish/default.vcl
 service varnish start
 chkconfig varnish on
 
-#remove the error sudo: sorry, you must have a tty to run sudo
-#see //github.com/mitchellh/vagrant-rackspace#centos--rhel--fedora
-sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
-
-
 # make an admin group
 groupadd admin
 # run the handsfree installer that's the same for all deployments


### PR DESCRIPTION
Basically this adds the new VM from puphpet, which breaks the tty thing for sudo. Rather it didn't correct it like the chef version did. So I am removing the required tty for Vagrant only. It probably isn't necessary to require tty anymore according to redhat's docs but i didn't want to assume anything. If you want that we can move the inline call into handsfree centos. 

As a bonus this vm out of the box handles RVM as a global... so the user on the system would just need to be added to the group rvm. Again i am not assuming "wants", though it would be real easy to add the vagrant user to the rvm group and you could bypass all need to dl and setup ruby on install.