### PR TITLE
Fixed Features Warning Notice: Undefined index: group in views_handler->ui_name() #268

### DIFF
--- a/core/dslmcode/profiles/cis-7.x-2.x/modules/features/cis_displays/cis_displays.views_default.inc
+++ b/core/dslmcode/profiles/cis-7.x-2.x/modules/features/cis_displays/cis_displays.views_default.inc
@@ -2585,10 +2585,6 @@ function cis_displays_views_default_views() {
   $handler->display->display_options['fields']['title']['label'] = '';
   $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
   $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
-  /* Field: : field_internal_classification */
-  $handler->display->display_options['fields']['field_internal_classification']['id'] = 'field_internal_classification';
-  $handler->display->display_options['fields']['field_internal_classification']['table'] = 'field_data_field_internal_classification';
-  $handler->display->display_options['fields']['field_internal_classification']['field'] = 'field_internal_classification';
   /* Field: Content: Edit link */
   $handler->display->display_options['fields']['edit_node']['id'] = 'edit_node';
   $handler->display->display_options['fields']['edit_node']['table'] = 'views_entity_node';

--- a/core/dslmcode/profiles/cis-7.x-2.x/modules/features/cis_types/cis_types.features.field_base.inc
+++ b/core/dslmcode/profiles/cis-7.x-2.x/modules/features/cis_types/cis_types.features.field_base.inc
@@ -1092,36 +1092,6 @@ function cis_types_field_default_field_bases() {
     'type' => 'entityreference',
   );
 
-  // Exported field_base: 'field_internal_classification'
-  $field_bases['field_internal_classification'] = array(
-    'active' => 1,
-    'cardinality' => 1,
-    'deleted' => 0,
-    'entity_types' => array(),
-    'field_name' => 'field_internal_classification',
-    'field_permissions' => array(
-      'type' => 0,
-    ),
-    'indexes' => array(
-      'value' => array(
-        0 => 'value',
-      ),
-    ),
-    'locked' => 0,
-    'module' => 'list',
-    'settings' => array(
-      'allowed_values' => array(
-        'faculty' => 'Faculty',
-        'staff' => 'Staff',
-      ),
-      'allowed_values_function' => '',
-      'cis_connector_access' => FALSE,
-      'cis_connector_disable' => FALSE,
-    ),
-    'translatable' => 0,
-    'type' => 'list_text',
-  );
-
   // Exported field_base: 'field_lead_instructor'
   $field_bases['field_lead_instructor'] = array(
     'active' => 1,

--- a/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
@@ -274,6 +274,7 @@ class views_handler extends views_object {
       return $title;
     }
     $title = ($short && isset($this->definition['title short'])) ? $this->definition['title short'] : $this->definition['title'];
+    dpm($this); // figure out what field is messed up ... turn on devel
     return t('!group: !title', array('!group' => $this->definition['group'], '!title' => $title));
   }
 

--- a/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
@@ -275,7 +275,10 @@ class views_handler extends views_object {
     }
     $title = ($short && isset($this->definition['title short'])) ? $this->definition['title short'] : $this->definition['title'];
     // Probably make some exception where if no group then figure it out
-    dpm($this->definition); // figure out what field is messed up ... turn on devel
+    //dpm(!$this->definition['group']); // figure out what field is messed up ... turn on devel
+    if (!$this->definition['group']){
+      dpm($this->definition);
+    }
     return t('!group: !title', array('!group' => $this->definition['group'], '!title' => $title));
   }
 

--- a/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
@@ -275,7 +275,7 @@ class views_handler extends views_object {
     }
     $title = ($short && isset($this->definition['title short'])) ? $this->definition['title short'] : $this->definition['title'];
     // Probably make some exception where if no group then figure it out
-    dpm($this->definition['group']); // figure out what field is messed up ... turn on devel
+    dpm($this->definition); // figure out what field is messed up ... turn on devel
     return t('!group: !title', array('!group' => $this->definition['group'], '!title' => $title));
   }
 

--- a/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
@@ -277,7 +277,7 @@ class views_handler extends views_object {
     // Probably make some exception where if no group then figure it out
     //dpm(!$this->definition['group']); // figure out what field is messed up ... turn on devel
     if (!$this->definition['group']){
-      dpm($this->definition);
+      dpm($this);
     }
     return t('!group: !title', array('!group' => $this->definition['group'], '!title' => $title));
   }

--- a/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
@@ -277,7 +277,7 @@ class views_handler extends views_object {
     // Probably make some exception where if no group then figure it out
     //dpm(!$this->definition['group']); // figure out what field is messed up ... turn on devel
     if (!$this->definition['group']){
-      dpm($this);
+      dpm($this->definition);
     }
     return t('!group: !title', array('!group' => $this->definition['group'], '!title' => $title));
   }

--- a/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
@@ -274,7 +274,8 @@ class views_handler extends views_object {
       return $title;
     }
     $title = ($short && isset($this->definition['title short'])) ? $this->definition['title short'] : $this->definition['title'];
-    dpm($this); // figure out what field is messed up ... turn on devel
+    // Probably make some exception where if no group then figure it out
+    dpm($this->definition['group']); // figure out what field is messed up ... turn on devel
     return t('!group: !title', array('!group' => $this->definition['group'], '!title' => $title));
   }
 

--- a/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/ulmus/views/includes/handlers.inc
@@ -274,11 +274,6 @@ class views_handler extends views_object {
       return $title;
     }
     $title = ($short && isset($this->definition['title short'])) ? $this->definition['title short'] : $this->definition['title'];
-    // Probably make some exception where if no group then figure it out
-    //dpm(!$this->definition['group']); // figure out what field is messed up ... turn on devel
-    if (!$this->definition['group']){
-      dpm($this->definition);
-    }
     return t('!group: !title', array('!group' => $this->definition['group'], '!title' => $title));
   }
 


### PR DESCRIPTION
I have fixed the Features Warning Notice: Undefined index: group in views_handler->ui_name() that was displayed when going to the 'Create New Feature' page. The problem was that the legacy field
   
    field_internal_classification     

was still being used in the cis-7.x-2.x source code. Removing lines that reference the old variable the Warning Notice goes away and the issue is resolved. 