### PR TITLE
Allow empty book outline pages to be the homepage.

### DIFF
--- a/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_helper_book_nav/mooc_helper_book_nav.module
+++ b/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_helper_book_nav/mooc_helper_book_nav.module
@@ -8,8 +8,8 @@
  * Implements hook_node_view().
  */
 function mooc_helper_book_nav_node_view($node, $view_mode, $langcode) {
-  // ensure this only happens for node's viewed in books and not front page
-  if (!drupal_is_front_page() && arg(0) == 'node' && $view_mode == 'full' && isset($node->book) && isset($node->body) && empty($node->body['und'][0]['value'])) {
+  // ensure this only happens for node's viewed in books
+  if (arg(0) == 'node' && $view_mode == 'full' && isset($node->book) && isset($node->body) && empty($node->body['und'][0]['value'])) {
     $next = book_next($node->book);
     // ensure we have a next item and it's in this one
     if ($next && $node->book['mlid'] == $next['plid']) {


### PR DESCRIPTION
Now now that we've added a menu callback `mooc/book-homepage` that dynaimcally switches the homepage depending on what section you are in, we need to allow empty pages redirects on the homepage.