### PR TITLE
UI Improvements for header region and copy to clipboard button

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/bower.json
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/bower.json
@@ -1,7 +1,8 @@
 {
   "name": "foundation-libsass-template",
   "dependencies": {
-    "foundation": "zurb/bower-foundation"
+    "foundation": "zurb/bower-foundation",
+    "material-design-iconic-font": "~2.2.0"
   },
   "devDependencies": {
     "modular-scale": "~2.1.1",

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/css/app.css
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/css/app.css
@@ -7250,7 +7250,7 @@ footer {
   overflow: hidden; }
 
 .sticky-wrapper.is-sticky {
-  z-index: 10000;
+  z-index: 100;
   position: absolute; }
 
 .row.full {
@@ -7831,11 +7831,16 @@ p.txtbk-intro {
 
 .r-header {
   background: white;
-  padding: 1em 0;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: 90rem; }
+  max-width: none;
+  padding: 1em 1em;
+  transition: padding .4s ease; }
+  @media screen and (min-width: 100em) {
+    .r-header {
+      padding-left: calc(50% - 45em);
+      padding-right: calc(50% - 45em); } }
   .r-header__left {
     width: 70%;
     float: left;
@@ -7874,17 +7879,16 @@ p.txtbk-intro {
       list-style: none;
       float: right; }
   .r-header__icon {
-    padding: 0 .5em;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
     color: black;
     -webkit-align-items: baseline;
         -ms-flex-align: baseline;
-            align-items: baseline; }
-    .r-header__icon .icon {
-      height: 1.8em;
-      width: 2em; }
+            align-items: baseline;
+    padding: .5em .75em; }
+    .r-header__icon i {
+      font-size: 1.75em; }
   .r-header .book-navigation-header {
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -7905,12 +7909,20 @@ p.txtbk-intro {
     .r-header .f-dropdown > ul {
       margin: 0; }
 
-.is-sticky > .r-header {
-  padding: .5em 0;
-  border-bottom: 1px solid #EEEEEE;
-  width: 100% !important;
-  left: 0;
-  right: 0; }
+.etb-book .is-sticky {
+  margin-bottom: 5em; }
+  .etb-book .is-sticky ~ * {
+    padding-top: 5em; }
+  .etb-book .is-sticky > .r-header {
+    border-bottom: 1px solid #EEEEEE;
+    width: 100% !important;
+    left: 0;
+    right: 0;
+    padding: 0 1em; }
+    @media screen and (min-width: 100em) {
+      .etb-book .is-sticky > .r-header {
+        padding-left: calc(50% - 45em);
+        padding-right: calc(50% - 45em); } }
 
 @media only screen and (min-width: 40.063em) {
   #r-header__icon--advanced.open,
@@ -7953,6 +7965,62 @@ p.txtbk-intro {
     border-right-color: transparent;
     border-left-color: transparent;
     border-bottom-color: transparent; }
+
+/*doc
+---
+title: Buttons
+name: 1button
+category:
+  - Components - Buttons
+---
+
+```html_example
+<a class="ev1-button"><i class="zmdi zmdi-copy"></i>Copy to clipboard</a>
+```
+
+```html_example
+<a class="ev1-button ev1-button--icon"><i class="zmdi zmdi-copy"></i>Copy to clipboard</a>
+```
+*/
+.ev1-button, .clipboard--button-only .clipboardjs-button {
+  background: #008CBA;
+  color: white;
+  border: none;
+  display: inline-block;
+  outline: 0;
+  text-transform: uppercase;
+  -webkit-tap-highlight-color: transparent;
+  text-decoration: none;
+  text-align: center;
+  display: inline-block;
+  position: relative;
+  overflow: hidden;
+  border-radius: 2px;
+  transition: .3s;
+  cursor: pointer;
+  vertical-align: middle;
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
+  padding: .5em 1em; }
+  .ev1-button i, .clipboard--button-only .clipboardjs-button i {
+    margin-right: .4em; }
+  .ev1-button:hover, .clipboard--button-only .clipboardjs-button:hover {
+    box-shadow: 0 5px 11px 0 rgba(0, 0, 0, 0.18), 0 4px 15px 0 rgba(0, 0, 0, 0.15);
+    color: white; }
+  .ev1-button--icon, .clipboard--button-only .clipboardjs-button {
+    width: 3.5em;
+    height: 3.5em;
+    border-radius: 50%;
+    text-indent: -9999px; }
+    .ev1-button--icon i, .clipboard--button-only .clipboardjs-button i {
+      text-indent: 0;
+      font-size: 1.4em;
+      position: absolute;
+      text-indent: 0;
+      top: 50%;
+      left: 50%;
+      -webkit-transform: translate(-50%, -50%);
+          -ms-transform: translate(-50%, -50%);
+              transform: translate(-50%, -50%); }
 
 /*doc
 ---
@@ -8880,45 +8948,19 @@ The figure label component is used to present textbook like captions to media el
     .f-dropdown--classic li a:hover {
       background-color: #EEEEEE !important; }
 
-/*doc
----
-title: Clipboard
-name: 1clipboard
-category:
-  - Components - Clipboard
----
-
-This component relies on the clipboardjs module to control its output.
-See clipboardjs_build_content().  We are then able to wrap it's output
-in the `clipboard` class.
-
-```html_example
-<div class="clipboard__wrapper">
-
-  <div class="clipboard clipboard--button-only">
-    <div id="clipboardjs-56a7de313af40">[ciscode|rev=1|tool=elmsmedia|item=2071|entity_type=node|render_display=display_mode|display_mode=full]</div>
-    <button class="clipboardjs-button form-submit" data-clipboard-alert="tooltip" data-clipboard-alert-text="Copy was successful!" data-clipboard-target="#clipboardjs-56a7de313af40" onclick="return false;" name="op" value="Click to copy token" type="button">Click to copy token</button>
-  </div>
-
-</div>
-```
-*/
 .clipboard__wrapper {
   position: relative;
   display: inline-block;
-  width: 100%;
-  border: 2px dashed transparent; }
-  .clipboard__wrapper:hover {
-    border-color: #EEEEEE; }
-    .clipboard__wrapper:hover .clipboard--button-only {
-      opacity: 1; }
+  width: 100%; }
+  .clipboard__wrapper:hover .clipboard--button-only {
+    opacity: 1; }
 
 .clipboard--button-only {
   opacity: 0;
   position: absolute;
   top: 0;
   right: 0;
-  z-index: 100;
+  z-index: 50;
   transition: all .2s ease-in;
   margin-top: -1px;
   margin-right: -1px; }
@@ -8928,7 +8970,17 @@ in the `clipboard` class.
     overflow: hidden;
     position: absolute !important;
     width: 1px; }
+  .clipboard--button-only .clipboardjs-button:before, .clipboard--button-only .clipboardjs-button.imagelightbox__close:after {
+    text-indent: 0;
+    font-size: 1.4em;
+    position: absolute;
+    text-indent: 0;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%); }
 
 .clipboard .clipboardjs-button {
-  background-color: #EEEEEE;
-  color: black; }
+  background-color: #008CBA;
+  color: white; }

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/hologram_config.yml
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/hologram_config.yml
@@ -13,10 +13,11 @@ custom_markdown: ./styleguide-theme/CortanaMarkdownRenderer.rb
 
 # List all css to include for the styleguide render examples (path from styleguide directory)
 css_include:
+  - '../css/foundation.min.css'
+  - '../css/normalize.css'
+  - '../bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.css'
   - '../css/app.css'
   - '../css/tweaks.css'
-  - '../css/normalize.css'
-  - '../css/foundation.min.css'
 
 # List all js to include for the styleguide render examples (path from styleguide directory)
 js_include:

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/scss/app.scss
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/scss/app.scss
@@ -47,6 +47,7 @@
 
 // Components
 @import "components/icons";
+@import "components/buttons";
 @import "components/pullquote";
 @import "components/image";
 @import "components/imagelightbox";
@@ -55,5 +56,3 @@
 @import "components/figurelabel";
 @import "components/dropdown";
 @import "components/clipboard";
-
-// elmsmedia

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/scss/components/_buttons.scss
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/scss/components/_buttons.scss
@@ -1,0 +1,70 @@
+/*doc
+---
+title: Buttons
+name: 1button
+category:
+  - Components - Buttons
+---
+
+```html_example
+<a class="ev1-button"><i class="zmdi zmdi-copy"></i>Copy to clipboard</a>
+```
+
+```html_example
+<a class="ev1-button ev1-button--icon"><i class="zmdi zmdi-copy"></i>Copy to clipboard</a>
+```
+*/
+
+$ev1-button--color: white;
+$ev1-button--bg-color: $primary-color;
+
+@mixin ev1-button__icon {
+  text-indent: 0;
+  font-size: 1.4em;
+  position: absolute;
+  text-indent: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.ev1-button {
+  background: $ev1-button--bg-color;
+  color: $ev1-button--color;
+  border: none;
+  display: inline-block;
+  outline: 0;
+  text-transform: uppercase;
+  -webkit-tap-highlight-color: transparent;
+  text-decoration: none;
+  text-align: center;
+  display: inline-block;
+  position: relative;
+  overflow: hidden;
+  border-radius: 2px;
+  transition: .3s;
+  cursor: pointer;
+  vertical-align: middle;
+  box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
+  padding: .5em 1em;
+
+  i {
+    margin-right: .4em;
+  }
+
+  &:hover {
+    box-shadow: 0 5px 11px 0 rgba(0,0,0,0.18),0 4px 15px 0 rgba(0,0,0,0.15);
+    color: $ev1-button--color;
+  }
+
+  &--icon {
+    width: 3.5em;
+    height: 3.5em;
+    border-radius: 50%;
+    text-indent: -9999px;
+
+    i {
+      @include ev1-button__icon;
+    }
+  }
+}

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/scss/components/_clipboard.scss
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/scss/components/_clipboard.scss
@@ -1,39 +1,13 @@
-/*doc
----
-title: Clipboard
-name: 1clipboard
-category:
-  - Components - Clipboard
----
-
-This component relies on the clipboardjs module to control its output.
-See clipboardjs_build_content().  We are then able to wrap it's output
-in the `clipboard` class.
-
-```html_example
-<div class="clipboard__wrapper">
-
-  <div class="clipboard clipboard--button-only">
-    <div id="clipboardjs-56a7de313af40">[ciscode|rev=1|tool=elmsmedia|item=2071|entity_type=node|render_display=display_mode|display_mode=full]</div>
-    <button class="clipboardjs-button form-submit" data-clipboard-alert="tooltip" data-clipboard-alert-text="Copy was successful!" data-clipboard-target="#clipboardjs-56a7de313af40" onclick="return false;" name="op" value="Click to copy token" type="button">Click to copy token</button>
-  </div>
-
-</div>
-```
-*/
-
 .clipboard {
   &__wrapper {
     position: relative;
     display: inline-block;
     width: 100%;
-    border: 2px dashed transparent;
 
     &:hover {
-      border-color: $smoke;
       .clipboard--button-only {
         opacity: 1;
-      } 
+      }
     }
   }
 
@@ -42,7 +16,7 @@ in the `clipboard` class.
     position: absolute;
     top: 0;
     right: 0;
-    z-index: 100;
+    z-index: 50;
     transition: all .2s ease-in;
     margin-top: -1px;
     margin-right: -1px;
@@ -50,10 +24,18 @@ in the `clipboard` class.
     > div:first-of-type {
       @include element-invisible;
     }
+
+    .clipboardjs-button {
+      @extend .ev1-button;
+      @extend .ev1-button--icon;
+      &:before {
+        @include ev1-button__icon;
+      }
+    }
   }
 
   .clipboardjs-button {
-    background-color: $smoke;
-    color: black;
+    background-color: $primary-color;
+    color: white;
   }
 }

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/scss/main-styles/_common.scss
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/scss/main-styles/_common.scss
@@ -2,7 +2,7 @@
 	overflow:hidden;
 }
 .sticky-wrapper.is-sticky {
-	z-index:10000;
+	z-index:100;
 	position:absolute;
 }
 .row.full {

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/scss/regions/_r-header.scss
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/scss/regions/_r-header.scss
@@ -1,8 +1,20 @@
+$r-header--padding: 1em;
+
+@mixin r-header-padding-max-width {
+	@media screen and (min-width:100em) {
+		// Trick to set max-width and keep padding
+		padding-left: calc(50% - 45em);
+		padding-right: calc(50% - 45em);
+	}
+}
+
 .r-header {
 	background: white;
-	padding: 1em 0;
 	display: flex;
-	max-width: 90rem;
+	max-width: none;
+	padding: 1em $r-header--padding;
+	@include r-header-padding-max-width;
+	transition: padding .4s ease;
 
 	&__left {
 		width: 70%;
@@ -30,20 +42,19 @@
 		&__list-item {
 			margin: 0;
 			padding: 0;
-			list-style: none;			
+			list-style: none;
 			float: right;
 		}
 	}
 
 	&__icon {
-		padding: 0 .5em;
 		display: flex;
 		color: black;
 		align-items: baseline;
+		padding: .5em .75em;
 
-		.icon {
-			height: 1.8em;
-			width: 2em;
+		i {
+			font-size: 1.75em;
 		}
 	}
 
@@ -54,7 +65,7 @@
 
 	ul.book-navigation-wrapper {
 		display: flex;
-		align-items: center;	
+		align-items: center;
 	}
 
 	.f-dropdown {
@@ -67,14 +78,28 @@
 	}
 }
 
-.is-sticky > .r-header {
-	padding: .5em 0;
-	border-bottom: 1px solid $smoke;
-	// need this to override the sticky navigation that sets 
-	// a calculated width that is stupid and dumb
-	width: 100% !important; 
-	left: 0;
-	right: 0;
+
+
+.etb-book .is-sticky {
+	margin-bottom: 5em;
+
+	// target the sibling of the sticky wrapper
+	// and give it some padding so there isn't a
+	// jerk when this element goes fixed.
+	& ~ * {
+		padding-top: $r-header--padding * 5;
+	}
+
+	> .r-header {
+		border-bottom: 1px solid $smoke;
+		// need this to override the sticky navigation that sets
+		// a calculated width that is stupid and dumb
+		width: 100% !important;
+		left: 0;
+		right: 0;
+		padding: 0 $r-header--padding;
+		@include r-header-padding-max-width;
+	}
 }
 
 // Possition the dropdown perfectly on the advanced

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_buttons.html
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_buttons.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
-    <title></title>
+    <title>Components - Buttons</title>
 
     <!-- Styleguide CSS -->
     <link rel="stylesheet" href="./theme-build/css/vendors.css">
@@ -85,7 +85,7 @@
             
               
               
-                <li><a href="components_-_buttons.html">Buttons</a></li>
+                <li><a class="active" href="components_-_buttons.html">Buttons</a></li>
               
             
           
@@ -157,6 +157,8 @@
 
     <header class="cortana-header sb-slide">
       
+        <h1>Buttons</h1>
+      
       <div id="open-left" class="cortana-menu-btn">
         <span></span>
         <span></span>
@@ -174,6 +176,10 @@
         <nav id="cortana-inside-nav" class="cortana-inside-nav" bs-affix>
           <ul bs-scrollspy-list data-offset="-30">
             
+              
+                <li><a href="#1button">Buttons</a></li>
+              
+            
           </ul>
         </nav>
 
@@ -182,63 +188,12 @@
 
 
 
-<h1>ELMSLN UI Styleguide</h1>
-
-<p><img src="https://raw.githubusercontent.com/michael-collins/elmsln-logos/master/png-lowres-solid/lowres_square-color.png" alt="ELMSLN" title="ELMS Learning Network"></p>
-
-<h2>About</h2>
-
-<p>This is a living styleguide for the ELMSLN Drupal theme. Here is an <a href="http://yago.github.io/Cortana-example/index.html">example styleguide</a> for reference.</p>
-
-<p>This is a living styleguide that exists to:</p>
-
-<ul>
-<li>maintain best practices of responsive web design by building UI componenets modularly</li>
-<li>reduce the barier of entry for designers and themers to participate and contribute</li>
-<li>establish a defined language and naming convention for UI elements</li>
-<li>provide a baseline for user experience, accessiblity, and visual regression testing</li>
-<li>increase the velocity of adding functionality by allowing developers to easily reuse UI components</li>
-</ul>
-
-<h2>Usage</h2>
-
-<p>When creating a new component in Sass, you can define the component by adding a docblock to the bottom of your <code>.scss</code> file.</p>
-</div><div class="codeBlock"><div class="highlight"><pre>/*doc
----
-title: Component Name
-name: componentname
-category: Components - Component Name
----
-
-A breif explanation on how to use this componenet and in what context would be most appropriate to use.
-
-```html_example
-&lt;div class="componentname"&gt;Lorem ipsum Pariatur in ullamco pariatur proident in culpa consequat mollit pariatur occaecat in ea consectetur ad.&lt;/p&gt;
-&lt;/div&gt;
-```
-
-*/
-</pre></div></div><div class="cortana-content">
-<h2>Installation</h2>
-
-<p>To contribute to this styleguide you will need to install the front-end stack that supports generating the css and js from the theme as well
-as the styleguide itself.</p>
-
-<p>From inside of the <a href="https://github.com/elmsln/elmsln/tree/master/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access">ELMSLN foundation_access theme</a>, 
-install Grunt, Hologram, and Bower globally</p>
-</div><div class="codeBlock"><div class="highlight"><pre>$ npm install -g grunt-cli grunt-hologram bower
-$ gem install bundler
-</pre></div></div><div class="cortana-content">
-<p>Install the dependencies</p>
-</div><div class="codeBlock"><div class="highlight"><pre>$ npm install
-$ bower install
-$ bundle install
-</pre></div></div><div class="cortana-content">
-<p>Run the Grunt Server</p>
-</div><div class="codeBlock"><div class="highlight"><pre>$ grunt styleguide
-</pre></div></div><div class="cortana-content">
-<p>By running <code>grunt styleguide</code> the browsersync plugin should open the styleguide automatically.  If it does not then visit this url <a href="http://localhost:3000/styleguide/index.html">http://localhost:3000/styleguide/index.html</a></p>
-
+<h1 id="1button">Buttons</h1>
+</div><div class="codeExample"><div class="exampleOutput"><a class="ev1-button"><i class="zmdi zmdi-copy"></i>Copy to clipboard</a>
+</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"ev1-button"</span><span class="nt">&gt;&lt;i</span> <span class="na">class=</span><span class="s">"zmdi zmdi-copy"</span><span class="nt">&gt;&lt;/i&gt;</span>Copy to clipboard<span class="nt">&lt;/a&gt;</span>
+</pre></div></div></div><div class="cortana-content"></div><div class="codeExample"><div class="exampleOutput"><a class="ev1-button ev1-button--icon"><i class="zmdi zmdi-copy"></i>Copy to clipboard</a>
+</div><div class="codeBlock"><div class="highlight"><pre><span class="nt">&lt;a</span> <span class="na">class=</span><span class="s">"ev1-button ev1-button--icon"</span><span class="nt">&gt;&lt;i</span> <span class="na">class=</span><span class="s">"zmdi zmdi-copy"</span><span class="nt">&gt;&lt;/i&gt;</span>Copy to clipboard<span class="nt">&lt;/a&gt;</span>
+</pre></div></div></div><div class="cortana-content">
         </div>
       </div>
     </div>

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_clipboard.html
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_clipboard.html
@@ -13,13 +13,15 @@
     <!-- Source CSS -->
     
       
-        <link rel="stylesheet" href="../css/app.css">
-      
-        <link rel="stylesheet" href="../css/tweaks.css">
+        <link rel="stylesheet" href="../css/foundation.min.css">
       
         <link rel="stylesheet" href="../css/normalize.css">
       
-        <link rel="stylesheet" href="../css/foundation.min.css">
+        <link rel="stylesheet" href="../bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.css">
+      
+        <link rel="stylesheet" href="../css/app.css">
+      
+        <link rel="stylesheet" href="../css/tweaks.css">
       
     
 
@@ -63,6 +65,9 @@
       
         
         
+      
+        
+        
           
         
       
@@ -79,6 +84,13 @@
         
           <h3>Components</h3>
           <ul>
+          
+            
+              
+              
+                <li><a href="components_-_buttons.html">Buttons</a></li>
+              
+            
           
             
               
@@ -128,6 +140,8 @@
         
           <h3>Widgets</h3>
           <ul>
+          
+            
           
             
           
@@ -229,6 +243,18 @@ in the <code>clipboard</code> class.</p>
       $scope.searchData = 
       [
         
+          
+        
+          
+            
+              
+              
+              {
+              "title": "Buttons",
+              "breadcrumb": "Components - Buttons > Buttons",
+              "path": "components_-_buttons.html#1button"
+              },
+            
           
         
           

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_figurelabel.html
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_figurelabel.html
@@ -13,13 +13,15 @@
     <!-- Source CSS -->
     
       
-        <link rel="stylesheet" href="../css/app.css">
-      
-        <link rel="stylesheet" href="../css/tweaks.css">
+        <link rel="stylesheet" href="../css/foundation.min.css">
       
         <link rel="stylesheet" href="../css/normalize.css">
       
-        <link rel="stylesheet" href="../css/foundation.min.css">
+        <link rel="stylesheet" href="../bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.css">
+      
+        <link rel="stylesheet" href="../css/app.css">
+      
+        <link rel="stylesheet" href="../css/tweaks.css">
       
     
 
@@ -83,7 +85,7 @@
             
               
               
-                <li><a href="components_-_clipboard.html">Clipboard</a></li>
+                <li><a href="components_-_buttons.html">Buttons</a></li>
               
             
           
@@ -260,9 +262,9 @@
               
               
               {
-              "title": "Clipboard",
-              "breadcrumb": "Components - Clipboard > Clipboard",
-              "path": "components_-_clipboard.html#1clipboard"
+              "title": "Buttons",
+              "breadcrumb": "Components - Buttons > Buttons",
+              "path": "components_-_buttons.html#1button"
               },
             
           

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_image.html
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_image.html
@@ -13,13 +13,15 @@
     <!-- Source CSS -->
     
       
-        <link rel="stylesheet" href="../css/app.css">
-      
-        <link rel="stylesheet" href="../css/tweaks.css">
+        <link rel="stylesheet" href="../css/foundation.min.css">
       
         <link rel="stylesheet" href="../css/normalize.css">
       
-        <link rel="stylesheet" href="../css/foundation.min.css">
+        <link rel="stylesheet" href="../bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.css">
+      
+        <link rel="stylesheet" href="../css/app.css">
+      
+        <link rel="stylesheet" href="../css/tweaks.css">
       
     
 
@@ -83,7 +85,7 @@
             
               
               
-                <li><a href="components_-_clipboard.html">Clipboard</a></li>
+                <li><a href="components_-_buttons.html">Buttons</a></li>
               
             
           
@@ -334,9 +336,9 @@
               
               
               {
-              "title": "Clipboard",
-              "breadcrumb": "Components - Clipboard > Clipboard",
-              "path": "components_-_clipboard.html#1clipboard"
+              "title": "Buttons",
+              "breadcrumb": "Components - Buttons > Buttons",
+              "path": "components_-_buttons.html#1button"
               },
             
           

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_mediasvg.html
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_mediasvg.html
@@ -13,13 +13,15 @@
     <!-- Source CSS -->
     
       
-        <link rel="stylesheet" href="../css/app.css">
-      
-        <link rel="stylesheet" href="../css/tweaks.css">
+        <link rel="stylesheet" href="../css/foundation.min.css">
       
         <link rel="stylesheet" href="../css/normalize.css">
       
-        <link rel="stylesheet" href="../css/foundation.min.css">
+        <link rel="stylesheet" href="../bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.css">
+      
+        <link rel="stylesheet" href="../css/app.css">
+      
+        <link rel="stylesheet" href="../css/tweaks.css">
       
     
 
@@ -83,7 +85,7 @@
             
               
               
-                <li><a href="components_-_clipboard.html">Clipboard</a></li>
+                <li><a href="components_-_buttons.html">Buttons</a></li>
               
             
           
@@ -336,9 +338,9 @@ attribute if their is alternative text present.</p>
               
               
               {
-              "title": "Clipboard",
-              "breadcrumb": "Components - Clipboard > Clipboard",
-              "path": "components_-_clipboard.html#1clipboard"
+              "title": "Buttons",
+              "breadcrumb": "Components - Buttons > Buttons",
+              "path": "components_-_buttons.html#1button"
               },
             
           

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_quote.html
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_-_quote.html
@@ -13,13 +13,15 @@
     <!-- Source CSS -->
     
       
-        <link rel="stylesheet" href="../css/app.css">
-      
-        <link rel="stylesheet" href="../css/tweaks.css">
+        <link rel="stylesheet" href="../css/foundation.min.css">
       
         <link rel="stylesheet" href="../css/normalize.css">
       
-        <link rel="stylesheet" href="../css/foundation.min.css">
+        <link rel="stylesheet" href="../bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.css">
+      
+        <link rel="stylesheet" href="../css/app.css">
+      
+        <link rel="stylesheet" href="../css/tweaks.css">
       
     
 
@@ -83,7 +85,7 @@
             
               
               
-                <li><a href="components_-_clipboard.html">Clipboard</a></li>
+                <li><a href="components_-_buttons.html">Buttons</a></li>
               
             
           
@@ -295,9 +297,9 @@
               
               
               {
-              "title": "Clipboard",
-              "breadcrumb": "Components - Clipboard > Clipboard",
-              "path": "components_-_clipboard.html#1clipboard"
+              "title": "Buttons",
+              "breadcrumb": "Components - Buttons > Buttons",
+              "path": "components_-_buttons.html#1button"
               },
             
           

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_mediavideo.html
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/components_mediavideo.html
@@ -13,13 +13,15 @@
     <!-- Source CSS -->
     
       
-        <link rel="stylesheet" href="../css/app.css">
-      
-        <link rel="stylesheet" href="../css/tweaks.css">
+        <link rel="stylesheet" href="../css/foundation.min.css">
       
         <link rel="stylesheet" href="../css/normalize.css">
       
-        <link rel="stylesheet" href="../css/foundation.min.css">
+        <link rel="stylesheet" href="../bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.css">
+      
+        <link rel="stylesheet" href="../css/app.css">
+      
+        <link rel="stylesheet" href="../css/tweaks.css">
       
     
 
@@ -83,7 +85,7 @@
             
               
               
-                <li><a href="components_-_clipboard.html">Clipboard</a></li>
+                <li><a href="components_-_buttons.html">Buttons</a></li>
               
             
           
@@ -325,9 +327,9 @@ and Vimeo.</p>
               
               
               {
-              "title": "Clipboard",
-              "breadcrumb": "Components - Clipboard > Clipboard",
-              "path": "components_-_clipboard.html#1clipboard"
+              "title": "Buttons",
+              "breadcrumb": "Components - Buttons > Buttons",
+              "path": "components_-_buttons.html#1button"
               },
             
           

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/index.html
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/index.html
@@ -13,13 +13,15 @@
     <!-- Source CSS -->
     
       
-        <link rel="stylesheet" href="../css/app.css">
-      
-        <link rel="stylesheet" href="../css/tweaks.css">
+        <link rel="stylesheet" href="../css/foundation.min.css">
       
         <link rel="stylesheet" href="../css/normalize.css">
       
-        <link rel="stylesheet" href="../css/foundation.min.css">
+        <link rel="stylesheet" href="../bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.css">
+      
+        <link rel="stylesheet" href="../css/app.css">
+      
+        <link rel="stylesheet" href="../css/tweaks.css">
       
     
 
@@ -83,7 +85,7 @@
             
               
               
-                <li><a href="components_-_clipboard.html">Clipboard</a></li>
+                <li><a href="components_-_buttons.html">Buttons</a></li>
               
             
           
@@ -267,9 +269,9 @@ $ bundle install
               
               
               {
-              "title": "Clipboard",
-              "breadcrumb": "Components - Clipboard > Clipboard",
-              "path": "components_-_clipboard.html#1clipboard"
+              "title": "Buttons",
+              "breadcrumb": "Components - Buttons > Buttons",
+              "path": "components_-_buttons.html#1button"
               },
             
           

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/widgets_imagelightbox.html
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/widgets_imagelightbox.html
@@ -13,13 +13,15 @@
     <!-- Source CSS -->
     
       
-        <link rel="stylesheet" href="../css/app.css">
-      
-        <link rel="stylesheet" href="../css/tweaks.css">
+        <link rel="stylesheet" href="../css/foundation.min.css">
       
         <link rel="stylesheet" href="../css/normalize.css">
       
-        <link rel="stylesheet" href="../css/foundation.min.css">
+        <link rel="stylesheet" href="../bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.css">
+      
+        <link rel="stylesheet" href="../css/app.css">
+      
+        <link rel="stylesheet" href="../css/tweaks.css">
       
     
 
@@ -83,7 +85,7 @@
             
               
               
-                <li><a href="components_-_clipboard.html">Clipboard</a></li>
+                <li><a href="components_-_buttons.html">Buttons</a></li>
               
             
           
@@ -226,9 +228,9 @@ tag that initiates the lightbox.</p>
               
               
               {
-              "title": "Clipboard",
-              "breadcrumb": "Components - Clipboard > Clipboard",
-              "path": "components_-_clipboard.html#1clipboard"
+              "title": "Buttons",
+              "breadcrumb": "Components - Buttons > Buttons",
+              "path": "components_-_buttons.html#1button"
               },
             
           

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/template.php
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/template.php
@@ -55,10 +55,13 @@ function foundation_access_preprocess_html(&$variables) {
       }
     }
   }
+  $variables['theme_path'] = base_path() . drupal_get_path('theme', 'foundation_access');
   drupal_add_css($css, array('type' => 'inline', 'group' => CSS_THEME, 'weight' => 1000));
   drupal_add_css('//fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic|Open+Sans:300,600,700)', array('type' => 'external', 'group' => CSS_THEME));
+  drupal_add_css(drupal_get_path('theme', 'foundation_access') . '/bower_components/material-design-iconic-font/dist/css/material-design-iconic-font.css');
+
+
   // theme path shorthand should be handled here
-  $variables['theme_path'] = base_path() . drupal_get_path('theme', 'foundation_access');
   foreach($variables['user']->roles as $role){
     $variables['classes_array'][] = 'role-' . drupal_html_class($role);
   }
@@ -293,6 +296,42 @@ function foundation_access_preprocess_node__inherit__svg(&$variables) {
   }
 }
 
+/**
+ * Implements hook_theme_registry_alter().
+ */
+function foundation_access_theme_registry_alter(&$theme_registry) {
+  // Add a template file for clipboardjs
+  $theme_registry['clipboardjs']['template'] = 'clipboardjs';
+  $theme_registry['clipboardjs']['preprocess functions'][] = 'template_preprocess_clipboardjs';
+}
+
+function foundation_access_preprocess_clipboardjs(&$variables) {
+  $variables['content'] = array();
+  $uniqid = uniqid('clipboardjs-');
+
+  $variables['content']['text'] = array(
+    '#type' => 'container',
+    '#attributes' => array(
+      'id' => $uniqid,
+    ),
+  );
+
+  $variables['content']['text']['markup'] = array(
+    '#markup' => $variables['text'],
+  );
+
+  $variables['content']['button'] = array(
+    '#type' => 'button',
+    '#value' => check_plain($variables['button_label']),
+    '#attributes' => array(
+      'class' => array('clipboardjs-button', 'zmdi', 'zmdi-copy'),
+      'data-clipboard-alert' => $variables['alert_style'],
+      'data-clipboard-alert-text' => $variables['alert_text'],
+      'data-clipboard-target' => '#' . $uniqid,
+      'onClick' => 'return false;',
+    ),
+  );
+}
 
 /**
  * Implements template_menu_link.

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/clipboardjs/clipboardjs.tpl.php
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/clipboardjs/clipboardjs.tpl.php
@@ -1,0 +1,1 @@
+<?php print render($content); ?>

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/system/page.tpl.php
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/system/page.tpl.php
@@ -28,45 +28,44 @@
                 <?php if (isset($edit_path)): ?>
                 <li class="r-header__edit-icons__list-item">
                   <a href="<?php print $edit_path; ?>" title="<?php print t('Edit content')?>" class="r-header__icon">
-                    <div class="icon icon-edit-black"></div>
+                    <i class="zmdi zmdi-edit"></i>
                   </a>
                 </li>
                 <?php endif; ?>
+                <?php if (!empty($cis_shortcodes)) : ?>
+                  <li class="r-header__edit-icons__list-item"><a href="#" title="<?php print t('Share')?>" class="r-header__icon" data-reveal-id="block-cis-shortcodes-cis-shortcodes-block-nav-modal" aria-controls="cis-shortcodes-drop" aria-expanded="false">
+                    <i class="zmdi zmdi-arrow-split"></i>
+                  </a></li>
+                <?php endif; ?>
+                <?php if (isset($speedreader) || isset($mespeak)) : ?>
+                  <li class="r-header__edit-icons__list-item"><a href="#" title="Speed Reader" class="r-header__icon" data-reveal-id="page-accessibility-menu" aria-controls="accessibility-drop" aria-expanded="false">
+                    <i class="zmdi zmdi-tune"></i>
+                  </a></li>
+                <?php endif; ?>
                 <!-- end Edit Icon -->
                 <?php if (!empty($tabs['#primary']) || !empty($tabs['#secondary']) || !empty($tabs_extras)): ?>
-                <li class="r-header__edit-icons__list-item">
-                  <a href="#" class="r-header__icon" data-dropdown="r-header__icon--advanced" aria-controls="r-header__icon--advanced" aria-expanded="false">
-                    <div class="icon icon-gear-outline"></div>
-                    <span class="icon--dropdown"></span>
-                  </a>
-                  <ul id="r-header__icon--advanced" data-dropdown-content class="f-dropdown f-dropdown--classic content" aria-hidden="true" tabindex="-1">
-                  <?php if (!empty($tabs)): ?>
-                      <?php print render($tabs); ?>
-                    <?php if (!empty($tabs2)): print render($tabs2); endif; ?>
-                  <?php endif; ?>
-                  <?php if ($action_links): ?>
-                      <?php print render($action_links); ?>
-                  <?php endif; ?>
-                  <?php if (isset($tabs_extras)): ksort($tabs_extras); ?>
-                   <?php foreach ($tabs_extras as $group) : ?>
-                    <?php foreach ($group as $button) : ?>
-                      <li><?php print $button; ?></li>
-                    <?php endforeach; ?>
-                   <?php endforeach; ?>
-                  <?php endif; ?>
-                  </ul>
-                </li>
-              <?php endif; ?>
-              <?php if (!empty($cis_shortcodes)) : ?>
-                <li class="r-header__edit-icons__list-item"><a href="#" class="r-header__icon r-header__icon-secondary" data-reveal-id="block-cis-shortcodes-cis-shortcodes-block-nav-modal" aria-controls="cis-shortcodes-drop" aria-expanded="false">
-                  <div class="icon-collab-black off-canvas-toolbar-item-icon"></div>
-                </a></li>
-              <?php endif; ?>
-              <?php if (isset($speedreader) || isset($mespeak)) : ?>
-                <li class="r-header__edit-icons__list-item"><a href="#" class="r-header__icon r-header__icon-secondary" data-reveal-id="page-accessibility-menu" aria-controls="accessibility-drop" aria-expanded="false">
-                  <div class="icon-access-black off-canvas-toolbar-item-icon"></div>
-                </a></li>
-              <?php endif; ?>
+                  <li class="r-header__edit-icons__list-item">
+                    <a href="#" title="<?php print t('More')?>" class="r-header__icon" data-dropdown="r-header__icon--advanced" aria-controls="r-header__icon--advanced" aria-expanded="false">
+                      <i class="zmdi zmdi-more-vert"></i>
+                    </a>
+                    <ul id="r-header__icon--advanced" data-dropdown-content class="f-dropdown f-dropdown--classic content" aria-hidden="true" tabindex="-1">
+                    <?php if (!empty($tabs)): ?>
+                        <?php print render($tabs); ?>
+                      <?php if (!empty($tabs2)): print render($tabs2); endif; ?>
+                    <?php endif; ?>
+                    <?php if ($action_links): ?>
+                        <?php print render($action_links); ?>
+                    <?php endif; ?>
+                    <?php if (isset($tabs_extras)): ksort($tabs_extras); ?>
+                     <?php foreach ($tabs_extras as $group) : ?>
+                      <?php foreach ($group as $button) : ?>
+                        <li><?php print $button; ?></li>
+                      <?php endforeach; ?>
+                     <?php endforeach; ?>
+                    <?php endif; ?>
+                    </ul>
+                  </li>
+                <?php endif; ?>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
- Added material design icons
- fixed r-header z-index so it doesn't cover up admin bar or lightboxes
- Rordered r-header icons
- r-header is less jerky when going to sticky
- Added button design component
- Styled clipboardjs button with new button component

## Screenshots

### Header region
<img width="1439" alt="screen shot 2016-02-02 at 9 39 19 pm" src="https://cloud.githubusercontent.com/assets/3428964/12771528/f3bb31b2-c9f7-11e5-8482-521e7fbbc7e6.png">

### Header region sticky
<img width="1440" alt="screen shot 2016-02-02 at 9 39 28 pm" src="https://cloud.githubusercontent.com/assets/3428964/12771536/fb11956e-c9f7-11e5-8a5d-729f428132e8.png">

### Copy to clipboard button on media view mode tab
<img width="1433" alt="screen shot 2016-02-02 at 9 40 03 pm" src="https://cloud.githubusercontent.com/assets/3428964/12771539/00ce6ba8-c9f8-11e5-8f6f-f84ecdfbd355.png">

