### PR TITLE
#559

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/features/cis_section/cis_section.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/features/cis_section/cis_section.module
@@ -584,14 +584,30 @@ function cis_section_url_inbound_alter(&$path, $original_path, $path_language) {
   $query = drupal_get_query_parameters();
   if (isset($query['elmsln_active_course']) && $section_id = $query['elmsln_active_course']) {
     // get a list of allowed sections for this user
-    $sections = cis_section_all_sections();
+    $sections = array();
+    // select field section data
+    $query = new EntityFieldQuery();
+    // pull all nodes
+    $query->entityCondition('entity_type', 'node')
+    // that are sections
+    ->entityCondition('bundle', 'section')
+    // that are published
+    ->propertyCondition('status', 1);
+    $result = $query->execute();
+    // ensure we have results
+    if (isset($result['node'])) {
+      $nids = array_keys($result['node']);
+      $results = entity_load('node', $nids);
+      // convert to a readable array of options
+      foreach ($results as $val) {
+        $section = $val->field_section_id['und'][0]['safe_value'];
+        $sections[$section] = $val->title;
+      }
+    }
     // check if the proposed section is in the list of allowed sections
     if (in_array($section_id, $sections) || _cis_connector_role_grouping('staff')) {
       // set the active session
       $_SESSION['cis_section_context'] = $section_id;
-    }
-    else {
-      drupal_set_message(t('You currently do not have access to section @section_id', array('@section_id' => $section_id)), 'warning');
     }
     // Remove the active course query parameter and proceed to the url
     unset($query['elmsln_active_course']);

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/features/cis_section/cis_section.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/features/cis_section/cis_section.module
@@ -581,8 +581,8 @@ function cis_section_user_insert(&$edit, $account, $category) {
  * Sets the active section for a user based on a query parameter.
  */
 function cis_section_url_inbound_alter(&$path, $original_path, $path_language) {
-  $query = drupal_get_query_parameters();
-  if (isset($query['elmsln_active_course']) && $section_id = $query['elmsln_active_course']) {
+  $query_params = drupal_get_query_parameters();
+  if (isset($query_params['elmsln_active_course']) && $section_id = $query_params['elmsln_active_course']) {
     // get a list of allowed sections for this user
     $sections = array();
     // select field section data
@@ -610,8 +610,8 @@ function cis_section_url_inbound_alter(&$path, $original_path, $path_language) {
       $_SESSION['cis_section_context'] = $section_id;
     }
     // Remove the active course query parameter and proceed to the url
-    unset($query['elmsln_active_course']);
-    drupal_goto($path, array('query' => $query));
+    unset($query_params['elmsln_active_course']);
+    drupal_goto($path, array('query' => $query_params));
   }
 }
 


### PR DESCRIPTION
@heyMP can you review this please. I noticed that it was possible for people to be given the "YOU ARE NOT IN THIS SECTION" incorrectly. The block is supposed to be preventing me sending you a link that logs you in but really that's like a 0.001% use-case. What we should do is block stuff and then if someone sends someone else a direct link that would switch sections we should add an additional -share prefix or something so we know that's what it is.