### PR TITLE
Make HUB work

### DIFF
--- a/core/dslmcode/profiles/eph-7.x-1.x/drupal-org.make
+++ b/core/dslmcode/profiles/eph-7.x-1.x/drupal-org.make
@@ -1,7 +1,0 @@
-; eph make file for d.o. usage
-core = "7.x"
-api = "2"
-
-; eph core includes everything needed to power eph
-projects[eph_core][version] = "1.x-dev"
-projects[eph_core][subdir] = "contrib"

--- a/core/dslmcode/stacks/hub/profiles/README.txt
+++ b/core/dslmcode/stacks/hub/profiles/README.txt
@@ -1,1 +1,0 @@
-./../../../cores/drupal-7/profiles/README.txt

--- a/scripts/developer/README.txt
+++ b/scripts/developer/README.txt
@@ -1,3 +1,0 @@
-Galaxy - scripts - developer
-
-These scripts help speed up and automate tasks involved in developing the system itself such as adding new tools / domains into the setup. It’s a layer beyond what is currently being tasked in drush via the elms add stack commands.

--- a/scripts/install/elmsln-install.sh
+++ b/scripts/install/elmsln-install.sh
@@ -67,7 +67,7 @@ do
   cd $elmsln/core/dslmcode/stacks
   cd "${stack}/profiles"
   # pull the name of the profile in this stack by ignoring core ones
-  profile=$(find . -maxdepth 1 -type l \( ! -iname "testing" ! -iname "minimal" ! -iname "standard" \) | sed 's/\///' | sed 's/\.//')
+  profile=$(find . -maxdepth 1 -type l \( ! -iname "testing" ! -iname "minimal" ! -iname "README.txt" ! -iname "standard" \) | sed 's/\///' | sed 's/\.//')
   # add distros to our list
   distros+=($profile)
   cd $profile
@@ -159,13 +159,6 @@ if [ ! -d ${moduledir}/${university}/${cissettings} ];
   # add the function to include this in build outs automatically
   echo -e "/**\n * Implements hook_cis_service_instance_options_alter().\n */\nfunction ${university}_${host}_settings_cis_service_instance_options_alter(&\$options, \$course, \$service) {\n  // modules we require for all builds\n  \$options['en'][] = '$cissettings';\n  \$options['en'][] = 'elmsln_bakery';\n}\n" >> $modulefile
 fi
-
-#test mysql login
-#mysql -u$dbsu -p$dbsupw -e exit
-#if [[ $? > 0 ]];then
-  #echo "mysql connection failed"
-  #exit 1
-#fi
 
 # make sure drush is happy before we begin drush calls
 drush cc drush

--- a/scripts/install/elmsln-install.sh
+++ b/scripts/install/elmsln-install.sh
@@ -87,7 +87,12 @@ do
       else
         buildlist+=($stack)
         instances+=('TRUE')
-        ignorelist+=('FALSE')
+        # special case for program hub
+        if [[ $profile == 'eph' ]]; then
+          ignorelist+=('TRUE')
+        else
+          ignorelist+=('FALSE')
+        fi
       fi
     fi
     # find the default title


### PR DESCRIPTION
Well that was weird. D 7.41 core introduced a README.txt file which dslm naturally auto symlinked in our create-new-tool.sh script. Then the installer thought it was another profile that we needed to rip into our installer... which would never work :)