### PR TITLE
Automatically modify /etc/hosts on elmsln.dev builds #594

### DIFF
--- a/scripts/install/handsfree/handsfree-install.sh
+++ b/scripts/install/handsfree/handsfree-install.sh
@@ -91,7 +91,7 @@ prefix=$7
 ip=$(hostname -I)
 # if this is our default dev box domain name then kick this into the hosts file
 # so that it works when they do it on their own machine
-if [ $domain == 'elmsln.dev' ]; then
+if [ $domain == 'elmsln.dev' ||  $domain == 'elmsln.local' ]; then
   elmslnwarn "ELMSLN Development settings detected, we will author your server's /etc/hosts file for you"
   echo "# ELMSLN development" >> /etc/hosts
   for stack in "${stacklist[@]}"

--- a/scripts/install/handsfree/handsfree-install.sh
+++ b/scripts/install/handsfree/handsfree-install.sh
@@ -81,8 +81,6 @@ source .bashrc
 chown -R root:root /var/www/elmsln
 # setup user as admin
 bash /var/www/elmsln/scripts/install/users/elmsln-admin-user.sh
-# install system and off we go
-bash /var/www/elmsln/scripts/install/elmsln-install.sh
 
 # give them a roadmap for mapping to this until proving a real domain
 cd /var/www/elmsln/core/dslmcode/stacks
@@ -91,20 +89,6 @@ domain=$5
 datadomain=$6
 prefix=$7
 ip=$(hostname -I)
-elmslnecho "If you are developing with this and don't have a valid domain yet you can copy the following into your local machine's /etc/hosts file:"
-elmslnecho "# ELMSLN development"
-# loop through and write each of these here
-for stack in "${stacklist[@]}"
-do
-  elmslnecho "${ip}      ${stack}.${domain}"
-done
-elmslnecho ""
-# loop again on webservices domains
-for stack in "${stacklist[@]}"
-do
-  elmslnecho "${ip}      ${prefix}${stack}.${datadomain}"
-done
-
 # if this is our default dev box domain name then kick this into the hosts file
 # so that it works when they do it on their own machine
 if [ $domain == 'elmsln.dev' ]; then
@@ -121,3 +105,19 @@ if [ $domain == 'elmsln.dev' ]; then
     echo "${ip}  ${prefix}${stack}.${datadomain}" >> /etc/hosts
   done
 fi
+
+# install system and off we go
+bash /var/www/elmsln/scripts/install/elmsln-install.sh
+elmslnecho "If you are developing with this and don't have a valid domain yet you can copy the following into your local machine's /etc/hosts file:"
+elmslnecho "# ELMSLN development"
+# loop through and write each of these here
+for stack in "${stacklist[@]}"
+do
+  elmslnecho "${ip}      ${stack}.${domain}"
+done
+elmslnecho ""
+# loop again on webservices domains
+for stack in "${stacklist[@]}"
+do
+  elmslnecho "${ip}      ${prefix}${stack}.${datadomain}"
+done

--- a/scripts/install/handsfree/handsfree-install.sh
+++ b/scripts/install/handsfree/handsfree-install.sh
@@ -104,3 +104,20 @@ for stack in "${stacklist[@]}"
 do
   elmslnecho "${ip}      ${prefix}${stack}.${datadomain}"
 done
+
+# if this is our default dev box domain name then kick this into the hosts file
+# so that it works when they do it on their own machine
+if [ $domain == 'elmsln.dev' ]; then
+  elmslnwarn "ELMSLN Development settings detected, we will author your server's /etc/hosts file for you"
+  echo "# ELMSLN development" >> /etc/hosts
+  for stack in "${stacklist[@]}"
+  do
+    echo "${ip}  ${stack}.${domain}" >> /etc/hosts
+  done
+  echo "" >> /etc/hosts
+  # loop again on webservices domains
+  for stack in "${stacklist[@]}"
+  do
+    echo "${ip}  ${prefix}${stack}.${datadomain}" >> /etc/hosts
+  done
+fi

--- a/scripts/install/root/elmsln-preinstall.sh
+++ b/scripts/install/root/elmsln-preinstall.sh
@@ -67,7 +67,7 @@ git commit -m "initial ELMSLN config"
 
 elmslnecho "Enter the git repo you want to keep config in sync with: (ex: {user}@{YOURPRIVATEREPO}:YOU/elmsln-config-YOURUNIT.git)"
 read gitrepo
-# ensure they type yes, this is a big deal command
+# ensure they type yes
 if [ "$gitrepo" != "" ]; then
   elmslnecho "attempting to push current structure to the repo listed"
   git remote add origin $gitrepo

--- a/scripts/local/bash/elmsln-git-pull-all.sh
+++ b/scripts/local/bash/elmsln-git-pull-all.sh
@@ -26,7 +26,7 @@ if [ -z $1 ]; then
   exit 1
 fi
 if [ -z $2 ]; then
-  elmslnwarn "please select a branch you want to update on (master)"
+  elmslnwarn "please select a branch you want to update on"
   exit 1
 fi
 

--- a/scripts/local/bash/elmsln-up-all.sh
+++ b/scripts/local/bash/elmsln-up-all.sh
@@ -26,11 +26,11 @@ if [ -z $1 ]; then
   exit 1
 fi
 if [ -z $2 ]; then
-  elmslnwarn "please select a branch you want to update on (master)"
+  elmslnwarn "please select a branch you want to update on"
   exit 1
 fi
 if [ -z $3 ]; then
-  elmslnwarn "select branch you want config directory to update on (master)"
+  elmslnwarn "select branch you want config directory to update"
   exit 1
 fi
 

--- a/scripts/upgrade/elmsln-git-config.sh
+++ b/scripts/upgrade/elmsln-git-config.sh
@@ -20,7 +20,7 @@ timestamp(){
 }
 
 if [ -z $1 ]; then
-  elmslnwarn "please select a branch you want to update (like master)"
+  elmslnwarn "please select a branch you want to update"
   exit 1
 fi
 

--- a/scripts/upgrade/elmsln-git-elmsln.sh
+++ b/scripts/upgrade/elmsln-git-elmsln.sh
@@ -20,7 +20,7 @@ timestamp(){
 }
 
 if [ -z $1 ]; then
-  elmslnwarn "please select a branch you want to update (like master)"
+  elmslnwarn "please select a branch you want to update"
   exit 1
 fi
 

--- a/scripts/upgrade/elmsln-upgrade-system.sh
+++ b/scripts/upgrade/elmsln-upgrade-system.sh
@@ -24,7 +24,7 @@ timestamp(){
 
 # set the branch via passed in command
 if [ -z $1 ]; then
-  elmslnwarn "please select a branch you want to update (like master)"
+  elmslnwarn "please select a branch you want to update"
   read branch
   if [ -z $branch ]; then
     exit 1

--- a/scripts/utilities/crontab/nightly-routine.sh
+++ b/scripts/utilities/crontab/nightly-routine.sh
@@ -29,7 +29,7 @@ drush @online hss field_collection_item --xmlrpcuid=1 --y
 # ping node resource on all systems just to seed some base-line caches
 drush @elmsln hsr node --xmlrpcuid=1 --y
 # @todo ping welcome_page on everything which will seed CIS calls
-# @todo need to spoof section during the request though or its just master
+# @todo need to spoof section during the request
 
 
 

--- a/scripts/vagrant/handsfree-vagrant.sh
+++ b/scripts/vagrant/handsfree-vagrant.sh
@@ -15,7 +15,7 @@ cp /var/www/elmsln-config-vagrant/shared/drupal-7.x/settings/shared_settings.php
 
 # some minor clean up that we need to do via sudo
 # setup host file so httprl works for local cache rebuilding
-cat /var/www/elmsln/scripts/vagrant/hosts >> /etc/hosts
+#cat /var/www/elmsln/scripts/vagrant/hosts >> /etc/hosts
 # add in checks to ensure apache/mysql haven't stopped
 # when we SSH into the box. For the purposes of drupal
 # and vagrant, these services should NEVER be stopped


### PR DESCRIPTION
The one line installer has elmsln.dev as the default; if this is used it's obviously not for production purposes and so should be treated as a development space (that happens to be out in the cloud). As such, we need the server to know that it's operating this way by automatically modifying it's /etc/hosts file.