### PR TITLE
#941 maintain course context across systems AND do contextual links

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/cis_connector.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/cis_connector.module
@@ -461,6 +461,9 @@ function _cis_connector_course_context() {
   // statically cache future calls
   $course = &drupal_static(__FUNCTION__);
   if (!isset($course)) {
+    // @todo we need a way of detecting course context RIGHT AFTER A FORM IS SAVED
+    // if the destination changes, we technically don't know the context at that time
+    // which is weird but true.
     // see if this is on a node, then check if we are in an authority
     if ($node = menu_get_object('node', 1, arg(0) . '/' . arg(1))) {
       // we are in an authority system
@@ -497,6 +500,11 @@ function _cis_connector_course_context() {
     if (isset($_SESSION['cis_course_context'])) {
       $course = $_SESSION['cis_course_context'];
       unset($_SESSION['cis_course_context']);
+      return $course;
+    }
+    // check for GET in address bar
+    if (isset($_GET['elmsln_course'])) {
+      $course = $_GET['elmsln_course'];
       return $course;
     }
     // use the variable that's been set for the machine name

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/cis_connector.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/cis_connector.module
@@ -984,9 +984,34 @@ function _cis_connector_request($url, $options = array(), $bucket = 'cis', $cach
   // statically cache future calls
   $data = &drupal_static($call);
   if (!isset($data)) {
-    // convert to something db friendly
+    // build a nice cid that's safe and targetable by pin-prick api
+    // cna hit just a bucket to destroy all entries
+    $cid_ary = array();
+    if ($bucket != 'none') {
+      $cid_ary[] = 'elmsln';
+    }
+    $cid_ary[] = $bucket;
+    // break up the url if we can
+    $tmp = explode('?', $url);
+    if (count($tmp) == 2) {
+      // try and abstract entity / entity id if possible
+      // split the format off the request like .json
+      $tmp = explode('.', $tmp[0]);
+      // split the address off
+      $tmp = explode('/', $tmp[0]);
+      // loop through remaining parts
+      foreach ($tmp as $cache_part) {
+        if ($cache_part != '') {
+          $cid_ary[] = $cache_part;
+        }
+      }
+    }
+    // salt this url since it might have sensitive data in it
     $salt = drupal_get_hash_salt();
-    $cid = hash('sha512', $salt . $call);
+    // this ensures that we don't get a match if anything
+    // else downstream changes based on address / query logic
+    $cid_ary[] = hash('sha512', $salt . $call);
+    $cid = implode(':', $cid_ary);
     // @ignore druplart_conditional_assignment
     if ($cached && ($cache = cache_get($cid, 'cache_cis_connector'))) {
       $data = $cache;

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_filter/cis_filter.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_filter/cis_filter.module
@@ -676,11 +676,13 @@ function cis_filter_menu_contextual_links_alter(&$links, $router_item, $root_pat
   // hook on a contextual path so we can redirect back here after
   // the operation takes place on the other end, assuming they hit edit
   if (in_array($root_path, array('elmsln/redirect/%/%/%'))) {
-    $links['cis_filter-edit']['localized_options'] = array(
-      'query' => array(
-        'destination' => 'elmsln/redirect/' . variable_get('install_profile', 'standard') .  '/' . arg(0) . '/' . arg(1),
-      )
-    );
+    foreach ($links as &$link) {
+      $link['localized_options'] = array(
+        'query' => array(
+          'destination' => 'elmsln/redirect/' . variable_get('install_profile', 'standard') .  '/' . arg(0) . '/' . arg(1),
+        )
+      );
+    }
     if ($course = _cis_connector_course_context()) {
       $links['cis_filter-edit']['localized_options']['query']['cis_course_context'] = $course;
     }

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_filter/cis_filter.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_filter/cis_filter.module
@@ -15,7 +15,6 @@ function cis_filter_menu() {
     'page callback' => '_cis_filter_modal_page',
     'access arguments' => array('access content'),
   );
-
   return $items;
 }
 
@@ -82,7 +81,8 @@ function _cis_filter_process($text, $filter, $format, $langcode, $cache, $cache_
             $instance = '/';
             if (isset($settings['instance']) && $settings['instance']) {
               $instance = base_path();
-              //test for non-subdomain installation
+              // @todo huh!? when would this EVER fire?
+              // test for non-subdomain installation
               $test = explode('/', $instance);
               if (count($test) == 4) {
                 $instance = '/' . $test[2] . '/';
@@ -106,7 +106,22 @@ function _cis_filter_process($text, $filter, $format, $langcode, $cache, $cache_
         ),
         'theme_hook_suggestion' => $template,
       );
-      $media[] = theme($render, $ary);
+      if (isset($code['item'])) {
+        $item_path = array($code['entity_type'], $code['item']);
+      }
+      else {
+        $item_path = explode('/', $code['link']);
+      }
+      $rendered = theme($render, $ary);
+      $render_array = array(
+        '#markup' => $rendered,
+        '#theme_wrappers' => array('contextual_container'),
+        '#contextual_links' => array(
+          'cis_filter' => array('elmsln/redirect', array($code['tool'], $item_path[0], $item_path[1])),
+        ),
+      );
+      $wrapper = drupal_render($render_array);
+      $media[] = $wrapper;
     }
     $text = preg_replace($patterns, $media, $text, 1);
   }
@@ -178,6 +193,14 @@ function cis_filter_theme() {
         'id' => '',
       ),
       'template' => 'templates/cis-filter-render--iframe',
+    ),
+    'cis_filter_contextual_links' => array(
+      'render element' => 'element',
+      'template' => 'templates/cis-filter-contextual-links',
+    ),
+    'contextual_container' => array(
+      'render element' => 'element',
+      'template' => 'templates/contextual-container',
     ),
   );
 }
@@ -471,7 +494,7 @@ function cis_filter_preprocess_cis_filter_render__submit(&$vars) {
                 else {
                   $text = t('Submit @name', array('@name' => $item['title']));
                 }
-                // present a modal for them to submit this thing
+                // present a modal for them to submit this thin
                 $vars['content'] = '<ul class="submit-widget-links"><li>' . ctools_modal_text_button($text, $link, t('Click this link to submit @name', array('@name' => html_entity_decode($item['title']))), 'ctools-modal-cis-filter-modal disable-scroll') . '</li></ul>';
                 $vars['class'] .= ' elmsln-action-unfinished';
               }
@@ -627,3 +650,40 @@ function _cis_filter_modal_page($js = NULL, $tool = NULL, $a1 = NULL, $a2 = NULL
   }
   return ctools_modal_render('Submission', $contents) ;
 }
+
+/**
+ * Implements preprocess_cis_filter_contextual_links()
+ */
+function cis_filter_preprocess_cis_filter_contextual_links(&$variables) {
+  $variables['classes_array'][] = $variables['element']['class'];
+  $variables['title'] = $variables['element']['title'];
+  $variables['content'] = $variables['element']['#children'];
+  $variables['more'] = $variables['element']['more'];
+}
+
+/**
+ * Implements hook_preprocess_contextual_container()
+ */
+function cis_filter_preprocess_contextual_container(&$variables) {
+  $variables['content'] = $variables['element']['#markup'];
+}
+
+/**
+ * Implements hook_menu_contextual_links_alter().
+ */
+
+function cis_filter_menu_contextual_links_alter(&$links, $router_item, $root_path) {
+  // hook on a contextual path so we can redirect back here after
+  // the operation takes place on the other end, assuming they hit edit
+  if (in_array($root_path, array('elmsln/redirect/%/%/%'))) {
+    $links['cis_filter-edit']['localized_options'] = array(
+      'query' => array(
+        'destination' => 'elmsln/redirect/' . variable_get('install_profile', 'standard') .  '/' . arg(0) . '/' . arg(1),
+      )
+    );
+    if ($course = _cis_connector_course_context()) {
+      $links['cis_filter-edit']['localized_options']['query']['cis_course_context'] = $course;
+    }
+  }
+}
+

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_filter/cis_filter.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_filter/cis_filter.module
@@ -680,11 +680,9 @@ function cis_filter_menu_contextual_links_alter(&$links, $router_item, $root_pat
       $link['localized_options'] = array(
         'query' => array(
           'destination' => 'elmsln/redirect/' . variable_get('install_profile', 'standard') .  '/' . arg(0) . '/' . arg(1),
+          'elmsln_course' => _cis_connector_course_context(),
         )
       );
-    }
-    if ($course = _cis_connector_course_context()) {
-      $links['cis_filter-edit']['localized_options']['query']['cis_course_context'] = $course;
     }
   }
 }

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_filter/templates/cis-filter-contextual-links.tpl.php
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_filter/templates/cis-filter-contextual-links.tpl.php
@@ -1,0 +1,14 @@
+<?php
+  /**
+   * Contextual Links template file
+   */
+?>
+<div class="<?php print $classes; ?>" <?php print $attributes; ?>>
+  <?php print render($title_prefix); ?>
+  <h2 <?php print $title_attributes; ?>><?php print $title;?></h2>
+  <div class="content"<?php print $content_attributes; ?>>
+    <?php print $content ?>
+  </div>
+  <?php print $more ?>
+  <?php print render($title_suffix); ?>
+</div>

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_filter/templates/contextual-container.tpl.php
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_filter/templates/contextual-container.tpl.php
@@ -1,0 +1,13 @@
+<?php
+  /**
+   * Contextual container for wrapping contextual links into page elements.
+   */
+?>
+<div class="<?php print $classes; ?>" <?php print $attributes; ?>>
+  <div <?php print $content_attributes; ?>>
+    <?php print $content ?>
+  </div>
+  <div class="custom-contextual-links">
+    <?php print render($title_suffix); ?>
+  </div>
+</div>

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/elmsln_api/callbacks/v1/clear_cache_bin.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/elmsln_api/callbacks/v1/clear_cache_bin.inc
@@ -10,13 +10,18 @@ function elmsln_api_elmsln_api_callback_clear_cache_bin() {
   if (isset($_elmsln['args']['bin'])) {
     // convert to cache bin name
     $bin = 'cache_' . $_elmsln['args']['bin'];
+    $cid = NULL;
+    if (isset($_elmsln['args']['cid'])) {
+      $cid = $_elmsln['args']['cid'];
+    }
     // make sure the bin exists
     if (db_table_exists($bin)) {
-      $db = db_delete($bin)->execute();
+      cache_clear_all($cid, $bin, TRUE);
       return array(
         'cleared' => TRUE,
         'bin' => $bin,
-        'message' => "$bin cleared successfully",
+        'cid' => $cid,
+        'message' => "$bin:$cid* cleared successfully",
       );
     }
   }

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/elmsln_api/elmsln_api.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/elmsln_api/elmsln_api.module
@@ -936,6 +936,8 @@ function elmsln_api_elmsln_api_info() {
   $callbacks['clear_cache_bin'] = array(
     'methods' => array('GET', 'POST'),
     'file' => 'callbacks/v1/clear_cache_bin.inc',
+    'includes' => array('cache'),
+    'dependencies' => array('system'),
   );
   // remote vset
   $callbacks['vset'] = array(

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/elmsln_core/elmsln_core.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/elmsln_core/elmsln_core.module
@@ -7,6 +7,73 @@
 include_once 'elmsln_core.features.inc';
 
 /**
+ * Implements hook_menu().
+ */
+function elmsln_core_menu() {
+  $items['elmsln/redirect/%/%/%'] = array(
+    'title' => 'view asset',
+    'page callback' => '_elmsln_core_remote_redirect',
+    'access arguments' => array('access content'),
+    'page arguments' => array(2, 3, 4, 'view'),
+    'weight' => 0,
+    'type' => MENU_LOCAL_TASK,
+    'context' => MENU_CONTEXT_PAGE | MENU_CONTEXT_INLINE,
+  );
+  $items['elmsln/redirect/%/%/%/view'] = array(
+    'title' => 'view asset',
+    'page callback' => '_elmsln_core_remote_redirect',
+    'access arguments' => array('access content'),
+    'page arguments' => array(2, 3, 4, 5),
+    'weight' => 0,
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+    'context' => MENU_CONTEXT_PAGE | MENU_CONTEXT_INLINE,
+  );
+  $items['elmsln/redirect/%/%/%/edit'] = array(
+    'title' => 'edit asset',
+    'page callback' => '_elmsln_core_remote_redirect',
+    'page arguments' => array(2, 3, 4, 5),
+    'access arguments' => array('access content'),
+    'weight' => 0,
+    'type' => MENU_LOCAL_TASK,
+    'context' => MENU_CONTEXT_PAGE | MENU_CONTEXT_INLINE,
+  );
+
+  return $items;
+}
+
+/**
+ * Allow for structured redirecting to other tools in the network.
+ *
+ * @param  string  $tool     tool to connect to in the registry
+ * @param  string  $type     entity type to point to
+ * @param  int     $etid     entity id
+ * @param  string  $op       view, edit, delete, etc, the entity operations
+ *
+ * @return                   nothing returned, should redirect to remote space
+ */
+function _elmsln_core_remote_redirect($tool, $type, $etid, $op) {
+  if ($settings = _cis_connector_build_registry($tool)) {
+    $instance = '/';
+    if (isset($settings['instance']) && $settings['instance']) {
+      $instance = '/' . _cis_connector_course_context() . '/';
+    }
+    $address = _cis_connector_format_address($settings, $instance, 'front') . $type . '/' . $etid . '/' . $op;
+    // allow for redirecting back to whatever was set
+    if (isset($_GET['destination'])) {
+      $address .= '?destination=' . $_GET['destination'];
+    }
+    if (isset($_GET['elmsln_course'])) {
+      $address .= '&cis_course_context=' . $_GET['elmsln_course'];
+    }
+    // redirect over to this location
+    header('Location: ' . $address, TRUE, 302);
+    // drupal_goto has this, says its important incase numeric code not understood
+    drupal_exit($address);
+  }
+  return t('This is not a valid tool in the network to create a link to.');
+}
+
+/**
  * Implements hook_permission().
  */
 function elmsln_core_permission() {
@@ -110,8 +177,8 @@ function elmsln_core_url_inbound_alter(&$path, $original_path, $path_language) {
   if (isset($query_params['elmsln_active_course']) && $course = $query_params['elmsln_active_course']) {
     $_SESSION['cis_course_context'] = $course;
     // Remove the active section query parameter and proceed to the url
-    unset($query_params['elmsln_active_course']);
-    $changed = TRUE;
+    //unset($query_params['elmsln_active_course']);
+    //$changed = TRUE;
   }
   // look or cross-network masquerade
   if (isset($query_params['elmsln_masquerade']) && $masquerad = $query_params['elmsln_masquerade']) {

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/elmsln_core/elmsln_core.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/elmsln_core/elmsln_core.module
@@ -13,7 +13,7 @@ function elmsln_core_menu() {
   $items['elmsln/redirect/%/%/%'] = array(
     'title' => 'view asset',
     'page callback' => '_elmsln_core_remote_redirect',
-    'access arguments' => array('access content'),
+    'access arguments' => array('view cis shortcode'),
     'page arguments' => array(2, 3, 4, 'view'),
     'weight' => 0,
     'type' => MENU_LOCAL_TASK,
@@ -22,7 +22,7 @@ function elmsln_core_menu() {
   $items['elmsln/redirect/%/%/%/view'] = array(
     'title' => 'view asset',
     'page callback' => '_elmsln_core_remote_redirect',
-    'access arguments' => array('access content'),
+    'access arguments' => array('view cis shortcode'),
     'page arguments' => array(2, 3, 4, 5),
     'weight' => 0,
     'type' => MENU_DEFAULT_LOCAL_TASK,
@@ -32,7 +32,7 @@ function elmsln_core_menu() {
     'title' => 'edit asset',
     'page callback' => '_elmsln_core_remote_redirect',
     'page arguments' => array(2, 3, 4, 5),
-    'access arguments' => array('access content'),
+    'access arguments' => array('view cis shortcode'),
     'weight' => 0,
     'type' => MENU_LOCAL_TASK,
     'context' => MENU_CONTEXT_PAGE | MENU_CONTEXT_INLINE,
@@ -63,7 +63,32 @@ function _elmsln_core_remote_redirect($tool, $type, $etid, $op) {
       $address .= '?destination=' . $_GET['destination'];
     }
     if (isset($_GET['elmsln_course'])) {
-      $address .= '&cis_course_context=' . $_GET['elmsln_course'];
+      $address .= '&elmsln_course=' . $_GET['elmsln_course'];
+    }
+    // look for a CID to destroy prior to redirect, this should ensure
+    // that the cached references to the item just modified are deleted
+    // as the user gets there so they end up repopulating caches with
+    // the data they just changed, always ensuring its fresh!
+    if (isset($_GET['elmsln_cid_target'])) {
+      $cid = 'elmsln:' . variable_get('install_profile', 'standard') . ':';
+      $path = explode('/', $_GET['elmsln_cid_target']);
+      if (count($path) > 1) {
+        $cid .= $path[0] . ':' . $path[1] . ':';
+      }
+      // sync the service but do it non-blocking
+      $request = array(
+        'method' => 'POST',
+        'api' => '1',
+        'bucket' => $tool,
+        'path' => $instance,
+        'data' => array(
+          'elmsln_module' => 'elmsln_api',
+          'elmsln_callback' => 'clear_cache_bin',
+          'bin' => 'cis_connector',
+          'cid' => $cid,
+        ),
+      );
+      $response = _elmsln_api_request($request);
     }
     // redirect over to this location
     header('Location: ' . $address, TRUE, 302);
@@ -71,6 +96,23 @@ function _elmsln_core_remote_redirect($tool, $type, $etid, $op) {
     drupal_exit($address);
   }
   return t('This is not a valid tool in the network to create a link to.');
+}
+
+/**
+ * Implements hook_drupal_goto_alter().
+ */
+function elmsln_core_drupal_goto_alter(&$path, &$options, &$http_response_code) {
+  // helper to propagate contextual data on redirects between systems
+  if (strpos($path, 'elmsln/redirect') === 0) {
+    // make sure course passes down through forms
+    // it's trippy but because elmsln/redirect doesn't load up using drupal_goto
+    // but is instead pointed to via one, this should ensure that we only ever
+    // do our remote cid destruction when needed and in the correct direction!
+    if (isset($_GET['elmsln_course'])) {
+      $options['query']['elmsln_course'] = filter_xss($_GET['elmsln_course']);
+    }
+    $options['query']['elmsln_cid_target'] = current_path();
+  }
 }
 
 /**

--- a/core/dslmcode/stacks/grades/sites/all/modules/contrib/quiz_ddlines/js/quiz_ddlines.js
+++ b/core/dslmcode/stacks/grades/sites/all/modules/contrib/quiz_ddlines/js/quiz_ddlines.js
@@ -336,7 +336,7 @@ Drupal.behaviors.quiz_ddlines = {
         if(engine.isNew()) {
           engine.addHelpText();
         }
-      }, ($.browser.msie ? 1000 : 0));
+      }, (navigator.userAgent.match(/msie/i) ? 1000 : 0));
     });
   }
 };


### PR DESCRIPTION
This branch brings in contextual links on all rendered shortcodes for developers / faculty / admins. Once media (for example) is placed in the content outline, if you hover over the media while viewing the content in the content outline you'll get a windy wheel to view / edit that item. This then links over to the appropriate system / content where you can make changes (if editing). Then on the return it frags the cached item reference meaning that you (and others) see the change reflected immediately without caching penalty.

This improves our cache tag granularity as well meaning we can remove things by asking to delete `elmsln:cis:node` which would delete all of the cached calls that were for nodes from CIS. also this could get to specific entity ids like `elmsln:cis:field_collection_item:662` meaning to delete all cached references to field collection 662 asked of the CIS. `elmsln:media:node:1256` and so on.