### PR TITLE
#1001 Removed Default Value

### DIFF
--- a/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_content_theming/mooc_content_theming.features.field_instance.inc
+++ b/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_content_theming/mooc_content_theming.features.field_instance.inc
@@ -111,11 +111,6 @@ function mooc_content_theming_field_default_field_instances() {
   // Exported field_instance: 'node-page-field_instructional_significance'
   $field_instances['node-page-field_instructional_significance'] = array(
     'bundle' => 'page',
-    'default_value' => array(
-      0 => array(
-        'value' => 'page',
-      ),
-    ),
     'deleted' => 0,
     'description' => '',
     'display' => array(


### PR DESCRIPTION
This fixes the issue of `-None-` not being the default for `field_instructional_significance`. Instructors will now have to choose the significance instead of having a `Page` specified by default.