### PR TITLE
Root composer drush fix

### DIFF
--- a/scripts/install/root/elmsln-preinstall.sh
+++ b/scripts/install/root/elmsln-preinstall.sh
@@ -397,6 +397,7 @@ yes | cp -rf /var/www/elmsln/scripts/drush/server/* $HOME/.drush/
 # stupid ubuntu drush thing to work with sudo
 if [[ $os == '2' ]]; then
   ln -s /root/.composer/vendor/drush/drush /usr/share/drush
+  ln -s /root/.config/composer/vendor/drush/drush /usr/share/drush
 fi
 drush cc drush
 # setup the standard user accounts to work on the backend

--- a/scripts/install/root/elmsln-preinstall.sh
+++ b/scripts/install/root/elmsln-preinstall.sh
@@ -383,6 +383,7 @@ echo "alias leafy='bash /var/www/elmsln/scripts/elmsln.sh'" >> .bashrc
 curl -sS https://getcomposer.org/installer | php
 mv composer.phar /usr/local/bin/composer
 sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' .bashrc
+echo 'export PATH="$HOME/.config/composer/vendor/bin:$PATH"' >> $HOME/.bashrc
 source $HOME/.bashrc
 
 # full path to execute in case root needs to log out before it picks it up

--- a/scripts/install/root/elmsln-preinstall.sh
+++ b/scripts/install/root/elmsln-preinstall.sh
@@ -383,7 +383,7 @@ echo "alias leafy='bash /var/www/elmsln/scripts/elmsln.sh'" >> .bashrc
 curl -sS https://getcomposer.org/installer | php
 mv composer.phar /usr/local/bin/composer
 sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' .bashrc
-echo 'export PATH="$HOME/.config/composer/vendor/bin:$PATH"' >> $HOME/.bashrc
+sed -i '1i export PATH="$HOME/.config/composer/vendor/bin:$PATH"' .bashrc
 source $HOME/.bashrc
 
 # full path to execute in case root needs to log out before it picks it up


### PR DESCRIPTION
This pull request is related to #987 
There are still some errors related to:

```
ln: failed to create symbolic link ‘/usr/share/drush’: File exists
unlink(/root/.config/composer/vendor/drush/drush/lib/package.xml): No[warning]
such file or directory drush.inc:691
'drush' cache was cleared.                                                                                                                                        [success]
groupadd: group 'elmsln' already exists
cp: cannot stat ‘/root/.composer’: No such file or directory
```
where now composer, when installed by root is in /root/.config/composer

and

```
/var/www/elmsln/scripts/install/users/elmsln-admin-user.sh: line 61: drush: command not found
/var/www/elmsln/scripts/install/users/elmsln-admin-user.sh: line 63: drush: command not found
```

where drush isn't installed yet at this point.

while these errors are present they do not affect elmsln installation. We can open another issue to clean up these errors if necessary. 

Since drush installing authority tool: blah is now working i say you can pull this in. 