### PR TITLE
#1036 Interact Caching Choices

### DIFF
--- a/core/dslmcode/profiles/icor-7.x-1.x/modules/features/icor_defaults/icor_defaults.install
+++ b/core/dslmcode/profiles/icor-7.x-1.x/modules/features/icor_defaults/icor_defaults.install
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * icor_defaults.install
+ */
+ /**
+ * Implements hook_update_N().
+ * Revert views component of cis_section
+ */
+function cis_section_update_7001(&$sandbox) {
+  features_revert(array('icor_defaults' => array('views')));
+}

--- a/core/dslmcode/profiles/icor-7.x-1.x/modules/features/icor_defaults/icor_defaults.views_default.inc
+++ b/core/dslmcode/profiles/icor-7.x-1.x/modules/features/icor_defaults/icor_defaults.views_default.inc
@@ -32,7 +32,11 @@ function icor_defaults_views_default_views() {
     166149871 => '166149871',
     67296478 => '67296478',
   );
-  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['cache']['type'] = 'time';
+  $handler->display->display_options['cache']['results_lifespan'] = '3600';
+  $handler->display->display_options['cache']['results_lifespan_custom'] = '0';
+  $handler->display->display_options['cache']['output_lifespan'] = '3600';
+  $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'full';
@@ -202,6 +206,7 @@ function icor_defaults_views_default_views() {
   $handler->display->display_options['bundles'] = array(
     0 => 'cis_course',
   );
+
   $export['icor_object_lists'] = $view;
 
   return $export;

--- a/core/dslmcode/profiles/icor-7.x-1.x/modules/features/icor_interactive_player/icor_interactive_player.install
+++ b/core/dslmcode/profiles/icor-7.x-1.x/modules/features/icor_interactive_player/icor_interactive_player.install
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @file
+ * icor_interactive_player.install
+ */
+
+/**
+ * Implements hook_update_N().
+ * Reverts the views component of icor_interactive_player
+ */
+function icor_interactive_player_update_7001(&$sandbox) {
+  features_revert(array('icor_interactive_player' => array('views')));
+}

--- a/core/dslmcode/profiles/icor-7.x-1.x/modules/features/icor_interactive_player/icor_interactive_player.views_default.inc
+++ b/core/dslmcode/profiles/icor-7.x-1.x/modules/features/icor_interactive_player/icor_interactive_player.views_default.inc
@@ -24,7 +24,11 @@ function icor_interactive_player_views_default_views() {
   $handler = $view->new_display('default', 'Master', 'default');
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'perm';
-  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['cache']['type'] = 'time';
+  $handler->display->display_options['cache']['results_lifespan'] = '1800';
+  $handler->display->display_options['cache']['results_lifespan_custom'] = '0';
+  $handler->display->display_options['cache']['output_lifespan'] = '1800';
+  $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['query']['options']['distinct'] = TRUE;
   $handler->display->display_options['exposed_form']['type'] = 'basic';

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/authorities/cis_course_authority/cis_course_authority.install
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/authorities/cis_course_authority/cis_course_authority.install
@@ -23,3 +23,15 @@ function cis_course_authority_update_7002(&$sandbox) {
   module_enable(array('ds'));
   features_revert_module('cis_course_authority');
 }
+/**
+ * Implements hook_update_N().
+ * Self revert and enable DS to pick up those settings for course form
+ */
+function cis_course_authority_update_7003(&$sandbox) {
+/**
+ * Implements hook_update_N().
+ * Reverts the views component of cis_course_authority
+ */
+  features_revert(array('cis_course_authority' => array('views')));
+
+}

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/authorities/cis_course_authority/cis_course_authority.install
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/authorities/cis_course_authority/cis_course_authority.install
@@ -28,10 +28,5 @@ function cis_course_authority_update_7002(&$sandbox) {
  * Self revert and enable DS to pick up those settings for course form
  */
 function cis_course_authority_update_7003(&$sandbox) {
-/**
- * Implements hook_update_N().
- * Reverts the views component of cis_course_authority
- */
   features_revert(array('cis_course_authority' => array('views')));
-
 }

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/authorities/cis_course_authority/cis_course_authority.views_default.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/authorities/cis_course_authority/cis_course_authority.views_default.inc
@@ -25,7 +25,11 @@ function cis_course_authority_views_default_views() {
   $handler->display->display_options['title'] = 'Course list';
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'perm';
-  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['cache']['type'] = 'time';
+  $handler->display->display_options['cache']['results_lifespan'] = '3600';
+  $handler->display->display_options['cache']['results_lifespan_custom'] = '0';
+  $handler->display->display_options['cache']['output_lifespan'] = '3600';
+  $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'full';

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/cis_section/cis_section.install
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/cis_section/cis_section.install
@@ -56,3 +56,10 @@ function cis_section_update_7002(&$sandbox) {
 function cis_section_update_7003(&$sandbox) {
   features_revert_module('cis_section');
 }
+
+/**
+ * Revert views component of cis_section
+ */
+function cis_section_update_7004(&$sandbox) {
+  features_revert(array('cis_section' => array('views')));
+}

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/cis_section/cis_section.views_default.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/cis_section/cis_section.views_default.inc
@@ -194,6 +194,111 @@ function cis_section_views_default_views() {
   $handler->display->display_options['menu']['name'] = 'menu-elmsln-settings';
   $handler->display->display_options['menu']['context'] = 0;
   $handler->display->display_options['menu']['context_only_inline'] = 0;
+  $export['cis_section_list'] = $view;
+
+  $view = new view();
+  $view->name = 'cis_user_list';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'users';
+  $view->human_name = 'CIS User list';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+  
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'User list';
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'role';
+  $handler->display->display_options['access']['role'] = array(
+    75987638 => 75987638,
+    166149871 => 166149871,
+    67296478 => 67296478,
+    76550217 => 76550217,
+  );
+  $handler->display->display_options['cache']['type'] = 'time';
+  $handler->display->display_options['cache']['results_lifespan'] = '3600';
+  $handler->display->display_options['cache']['results_lifespan_custom'] = '0';
+  $handler->display->display_options['cache']['output_lifespan'] = '3600';
+  $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+  $handler->display->display_options['style_plugin'] = 'table';
+  /* Field: User: Name */
+  $handler->display->display_options['fields']['name']['id'] = 'name';
+  $handler->display->display_options['fields']['name']['table'] = 'users';
+  $handler->display->display_options['fields']['name']['field'] = 'name';
+  $handler->display->display_options['fields']['name']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['name']['alter']['ellipsis'] = FALSE;
+  /* Field: User: Roles */
+  $handler->display->display_options['fields']['rid']['id'] = 'rid';
+  $handler->display->display_options['fields']['rid']['table'] = 'users_roles';
+  $handler->display->display_options['fields']['rid']['field'] = 'rid';
+  /* Sort criterion: User: Created date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'users';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+  /* Filter criterion: User: Active */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'users';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = '1';
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: User: Roles */
+  $handler->display->display_options['filters']['rid']['id'] = 'rid';
+  $handler->display->display_options['filters']['rid']['table'] = 'users_roles';
+  $handler->display->display_options['filters']['rid']['field'] = 'rid';
+  $handler->display->display_options['filters']['rid']['value'] = array(
+    6065076 => 6065076,
+    75987638 => 75987638,
+    135574917 => 135574917,
+    166149871 => 166149871,
+    66784200 => 66784200,
+    67296478 => 67296478,
+    30037204 => 30037204,
+  );
+  /* Filter criterion: User: Roles */
+  $handler->display->display_options['filters']['rid_1']['id'] = 'rid_1';
+  $handler->display->display_options['filters']['rid_1']['table'] = 'users_roles';
+  $handler->display->display_options['filters']['rid_1']['field'] = 'rid';
+  $handler->display->display_options['filters']['rid_1']['value'] = array(
+    6065076 => 6065076,
+    75987638 => 75987638,
+    135574917 => 135574917,
+    166149871 => 166149871,
+    66784200 => 66784200,
+    67296478 => 67296478,
+    30037204 => 30037204,
+  );
+  $handler->display->display_options['filters']['rid_1']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['rid_1']['expose']['operator_id'] = 'rid_1_op';
+  $handler->display->display_options['filters']['rid_1']['expose']['label'] = 'Roles';
+  $handler->display->display_options['filters']['rid_1']['expose']['operator'] = 'rid_1_op';
+  $handler->display->display_options['filters']['rid_1']['expose']['identifier'] = 'rid_1';
+  $handler->display->display_options['filters']['rid_1']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    6065076 => 0,
+    75987638 => 0,
+    135574917 => 0,
+    166149871 => 0,
+    66784200 => 0,
+    67296478 => 0,
+    30037204 => 0,
+  );
+  $handler->display->display_options['filters']['rid_1']['expose']['reduce'] = TRUE;
+  
+  /* Display: Page */
+  $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['path'] = 'cis/user-list';
+  $handler->display->display_options['menu']['type'] = 'normal';
+  $handler->display->display_options['menu']['title'] = 'Users';
+  $handler->display->display_options['menu']['name'] = 'menu-elmsln-settings';
   $export['cis_user_list'] = $view;
 
   return $export;

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/cis_section/cis_section.views_default.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/cis_section/cis_section.views_default.inc
@@ -31,7 +31,11 @@ function cis_section_views_default_views() {
     166149871 => 166149871,
     67296478 => 67296478,
   );
-  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['cache']['type'] = 'time';
+  $handler->display->display_options['cache']['results_lifespan'] = '3600';
+  $handler->display->display_options['cache']['results_lifespan_custom'] = '0';
+  $handler->display->display_options['cache']['output_lifespan'] = '3600';
+  $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'full';
@@ -190,107 +194,6 @@ function cis_section_views_default_views() {
   $handler->display->display_options['menu']['name'] = 'menu-elmsln-settings';
   $handler->display->display_options['menu']['context'] = 0;
   $handler->display->display_options['menu']['context_only_inline'] = 0;
-  $export['cis_section_list'] = $view;
-
-  $view = new view();
-  $view->name = 'cis_user_list';
-  $view->description = '';
-  $view->tag = 'default';
-  $view->base_table = 'users';
-  $view->human_name = 'CIS User list';
-  $view->core = 7;
-  $view->api_version = '3.0';
-  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
-
-  /* Display: Master */
-  $handler = $view->new_display('default', 'Master', 'default');
-  $handler->display->display_options['title'] = 'User list';
-  $handler->display->display_options['use_more_always'] = FALSE;
-  $handler->display->display_options['access']['type'] = 'role';
-  $handler->display->display_options['access']['role'] = array(
-    75987638 => 75987638,
-    166149871 => 166149871,
-    67296478 => 67296478,
-    76550217 => 76550217,
-  );
-  $handler->display->display_options['cache']['type'] = 'none';
-  $handler->display->display_options['query']['type'] = 'views_query';
-  $handler->display->display_options['exposed_form']['type'] = 'basic';
-  $handler->display->display_options['pager']['type'] = 'full';
-  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
-  $handler->display->display_options['style_plugin'] = 'table';
-  /* Field: User: Name */
-  $handler->display->display_options['fields']['name']['id'] = 'name';
-  $handler->display->display_options['fields']['name']['table'] = 'users';
-  $handler->display->display_options['fields']['name']['field'] = 'name';
-  $handler->display->display_options['fields']['name']['alter']['word_boundary'] = FALSE;
-  $handler->display->display_options['fields']['name']['alter']['ellipsis'] = FALSE;
-  /* Field: User: Roles */
-  $handler->display->display_options['fields']['rid']['id'] = 'rid';
-  $handler->display->display_options['fields']['rid']['table'] = 'users_roles';
-  $handler->display->display_options['fields']['rid']['field'] = 'rid';
-  /* Sort criterion: User: Created date */
-  $handler->display->display_options['sorts']['created']['id'] = 'created';
-  $handler->display->display_options['sorts']['created']['table'] = 'users';
-  $handler->display->display_options['sorts']['created']['field'] = 'created';
-  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
-  /* Filter criterion: User: Active */
-  $handler->display->display_options['filters']['status']['id'] = 'status';
-  $handler->display->display_options['filters']['status']['table'] = 'users';
-  $handler->display->display_options['filters']['status']['field'] = 'status';
-  $handler->display->display_options['filters']['status']['value'] = '1';
-  $handler->display->display_options['filters']['status']['group'] = 1;
-  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
-  /* Filter criterion: User: Roles */
-  $handler->display->display_options['filters']['rid']['id'] = 'rid';
-  $handler->display->display_options['filters']['rid']['table'] = 'users_roles';
-  $handler->display->display_options['filters']['rid']['field'] = 'rid';
-  $handler->display->display_options['filters']['rid']['value'] = array(
-    6065076 => 6065076,
-    75987638 => 75987638,
-    135574917 => 135574917,
-    166149871 => 166149871,
-    66784200 => 66784200,
-    67296478 => 67296478,
-    30037204 => 30037204,
-  );
-  /* Filter criterion: User: Roles */
-  $handler->display->display_options['filters']['rid_1']['id'] = 'rid_1';
-  $handler->display->display_options['filters']['rid_1']['table'] = 'users_roles';
-  $handler->display->display_options['filters']['rid_1']['field'] = 'rid';
-  $handler->display->display_options['filters']['rid_1']['value'] = array(
-    6065076 => 6065076,
-    75987638 => 75987638,
-    135574917 => 135574917,
-    166149871 => 166149871,
-    66784200 => 66784200,
-    67296478 => 67296478,
-    30037204 => 30037204,
-  );
-  $handler->display->display_options['filters']['rid_1']['exposed'] = TRUE;
-  $handler->display->display_options['filters']['rid_1']['expose']['operator_id'] = 'rid_1_op';
-  $handler->display->display_options['filters']['rid_1']['expose']['label'] = 'Roles';
-  $handler->display->display_options['filters']['rid_1']['expose']['operator'] = 'rid_1_op';
-  $handler->display->display_options['filters']['rid_1']['expose']['identifier'] = 'rid_1';
-  $handler->display->display_options['filters']['rid_1']['expose']['remember_roles'] = array(
-    2 => '2',
-    1 => 0,
-    6065076 => 0,
-    75987638 => 0,
-    135574917 => 0,
-    166149871 => 0,
-    66784200 => 0,
-    67296478 => 0,
-    30037204 => 0,
-  );
-  $handler->display->display_options['filters']['rid_1']['expose']['reduce'] = TRUE;
-
-  /* Display: Page */
-  $handler = $view->new_display('page', 'Page', 'page');
-  $handler->display->display_options['path'] = 'cis/user-list';
-  $handler->display->display_options['menu']['type'] = 'normal';
-  $handler->display->display_options['menu']['title'] = 'Users';
-  $handler->display->display_options['menu']['name'] = 'menu-elmsln-settings';
   $export['cis_user_list'] = $view;
 
   return $export;

--- a/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs/views_timelinejs.install
+++ b/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs/views_timelinejs.install
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * Code for the Views TimelineJS.
+ */
+function views_timelinejs_update_7001(&$sandbox) {
+/**
+ * Implements hook_update_N().
+ * Reverts the views component of views_timelinejs
+ */
+  features_revert(array('views_timelinejs' => array('views')));
+}

--- a/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs/views_timelinejs.install
+++ b/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs/views_timelinejs.install
@@ -4,9 +4,5 @@
  * Code for the Views TimelineJS.
  */
 function views_timelinejs_update_7001(&$sandbox) {
-/**
- * Implements hook_update_N().
- * Reverts the views component of views_timelinejs
- */
   features_revert(array('views_timelinejs' => array('views')));
 }

--- a/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs/views_timelinejs_feature/views_timelinejs_feature.views_default.inc
+++ b/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs/views_timelinejs_feature/views_timelinejs_feature.views_default.inc
@@ -25,7 +25,11 @@ function views_timelinejs_feature_views_default_views() {
   $handler->display->display_options['title'] = 'Timeline';
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'perm';
-  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['cache']['type'] = 'time';
+  $handler->display->display_options['cache']['results_lifespan'] = '1800';
+  $handler->display->display_options['cache']['results_lifespan_custom'] = '0';
+  $handler->display->display_options['cache']['output_lifespan'] = '1800';
+  $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'none';
@@ -46,7 +50,7 @@ function views_timelinejs_feature_views_default_views() {
     'hash_bookmark' => '0',
     'start_at_end' => '0',
   );
-  /* Field: Content: Body */
+  /* Field: Content: Text */
   $handler->display->display_options['fields']['body']['id'] = 'body';
   $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
   $handler->display->display_options['fields']['body']['field'] = 'body';

--- a/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs_extras/views_timelinejs_extras.install
+++ b/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs_extras/views_timelinejs_extras.install
@@ -4,9 +4,5 @@
  * Code for the Views TimelineJS Extras.
  */
 function views_timelinejs_extras_update_7001(&$sandbox) {
-/**
- * Implements hook_update_N().
- * Reverts the views component of views_timelinejs
- */
   features_revert(array('views_timelinejs_extras' => array('views')));
 }

--- a/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs_extras/views_timelinejs_extras.install
+++ b/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs_extras/views_timelinejs_extras.install
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * Code for the Views TimelineJS Extras.
+ */
+function views_timelinejs_extras_update_7001(&$sandbox) {
+/**
+ * Implements hook_update_N().
+ * Reverts the views component of views_timelinejs
+ */
+  features_revert(array('views_timelinejs_extras' => array('views')));
+}

--- a/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs_extras/views_timelinejs_extras.views_default.inc
+++ b/core/dslmcode/stacks/interact/sites/all/modules/local_contrib/views_timelinejs_extras/views_timelinejs_extras.views_default.inc
@@ -25,7 +25,11 @@ function views_timelinejs_extras_views_default_views() {
   $handler->display->display_options['title'] = 'Timeline';
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'perm';
-  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['cache']['type'] = 'time';
+  $handler->display->display_options['cache']['results_lifespan'] = '1800';
+  $handler->display->display_options['cache']['results_lifespan_custom'] = '0';
+  $handler->display->display_options['cache']['output_lifespan'] = '1800';
+  $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['pager']['type'] = 'none';
@@ -53,7 +57,7 @@ function views_timelinejs_extras_views_default_views() {
     'start_at_end' => '0',
     'start_zoom_adjust' => '0',
   );
-  /* Field: Content: Body */
+  /* Field: Content: Text */
   $handler->display->display_options['fields']['body']['id'] = 'body';
   $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
   $handler->display->display_options['fields']['body']['field'] = 'body';
@@ -169,7 +173,7 @@ function views_timelinejs_extras_views_default_views() {
     'multiple_from' => '',
     'multiple_to' => '',
   );
-  /* Field: Content: Body */
+  /* Field: Content: Text */
   $handler->display->display_options['fields']['body']['id'] = 'body';
   $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
   $handler->display->display_options['fields']['body']['field'] = 'body';


### PR DESCRIPTION
Caching is now active for Interact. Added update hooks for each of the files that were changed. Issue: `CIS User List` does not seem to exist in our CIS folder structure. Details of the caching times are listed below:

Interact Choices:

- [x] `CIS Authority Courses` = 1 day
- [x] `CIS Section list` = 1 day
- [x] `CIS User list` = 1 day (`CIS User List` folder or exported views feature file does not currently exist...will make issue to either create or find where it went.)
- [x] `icor object lists` = 1 day
- [x] `ICOR Player EVA` = 30 min
- [x] `Timeline` = 30 min
- [x] `Timeline Content type` = 30 min

#1055 
