### PR TITLE
fixes centos7 drush and group issues

### DIFF
--- a/scripts/vagrant/handsfree-vagrant.sh
+++ b/scripts/vagrant/handsfree-vagrant.sh
@@ -60,7 +60,9 @@ drush @online en vagrant_cis_dev cis_example_cis --y
 # restart apache to frag some caches because of the different settings that changed inside
 service httpd restart
 
-su - vagrant 'bash -s' /var/www/elmsln/scripts/install/users/elmsln-admin-user.sh /home/vagrant
+su - vagrant bash /var/www/elmsln/scripts/install/users/elmsln-admin-user.sh /home/vagrant
+
+sed -i '1i export PATH="/home/vagrant/.config/composer/vendor/bin:$PATH"' /home/vagrant/.bashrc
 
 # add vagrant to the elmsln group
 usermod -a -G elmsln vagrant

--- a/scripts/vagrant/handsfree-vagrant.sh
+++ b/scripts/vagrant/handsfree-vagrant.sh
@@ -58,4 +58,24 @@ drush @online dis seckit --y
 # specific stuff for aiding in development
 drush @online en vagrant_cis_dev cis_example_cis --y
 # restart apache to frag some caches because of the different settings that changed inside
-sudo /etc/init.d/httpd restart
+service httpd restart
+
+su - vagrant 'bash -s' /var/www/elmsln/scripts/install/users/elmsln-admin-user.sh /home/vagrant
+
+# add vagrant to the elmsln group
+usermod -a -G elmsln vagrant
+
+# set all permissions correctly and for vagrant user
+bash /var/www/elmsln/scripts/utilities/harden-security.sh vagrant
+
+# disable varnish which the Cent 6.x image enables by default
+# this way when we're doing local development we don't get cached anything
+# port swap to not use varnish in local dev
+sed -i 's/Listen 8080/Listen 80/g' /etc/httpd/conf/httpd.conf
+sed -i 's/8080/80/g' /etc/httpd/conf.d/*.conf
+service varnish stop
+service httpd restart
+service mysqld restart
+
+# disable varnish from starting automatically on reboot
+chkconfig varnish off


### PR DESCRIPTION
basically the proper elevated permissions weren't being set after the rhel7/centos7 update occurred. While this isn't the perfect or most elegant solution it fixes the problem without disrupting anything system wide. 