### PR TITLE
Solves the my.cnf issue

### DIFF
--- a/scripts/install/root/elmsln-preinstall.sh
+++ b/scripts/install/root/elmsln-preinstall.sh
@@ -141,7 +141,7 @@ elif [ $os == '3' ]; then
   phpini="/etc/php.ini"
   elmslnecho "php.ini automatically set to ${phpini}"
   # our install sets this up ahead of time
-  mycnf=""
+  mycnf="/etc/my.cnf"
   elmslnecho "my.cnf automatically set to ${mycnf}"
   crontab="/etc/crontab"
   elmslnecho "crontab automatically set to ${crontab}"

--- a/scripts/server/my.txt
+++ b/scripts/server/my.txt
@@ -3,7 +3,7 @@
 
 ; From real world testing ;
 table_definition_cache = 4000
-table_cache = 512
+table_open_cache = 512
 sort_buffer_size = 2M
 read_buffer_size = 2M
 read_rnd_buffer_size = 8M


### PR DESCRIPTION
This luckily makes more sense than having to create an extra my.txt file.

Premise being that in probably the oldest we would have to support (rhel6) this works since the naming of table_cache to table_open_cache was backported. 