### PR TITLE
Installation Order - swap epel and remi

### DIFF
--- a/scripts/install/handsfree/centos/example-deploy
+++ b/scripts/install/handsfree/centos/example-deploy
@@ -10,10 +10,10 @@
 # the real deal to be deployed somewhere.
 # get the epel and remi repo listings so we can get additional packages like mcrypt
 yes | yum -y install wget git
-wget http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
-rpm -Uvh remi-release-6*.rpm
 wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 rpm -Uvh epel-release-6*.rpm
+wget http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
+rpm -Uvh remi-release-6*.rpm
 git clone https://github.com/elmsln/elmsln.git /var/www/elmsln && bash /var/www/elmsln/scripts/install/handsfree/centos/centos-install.sh elmsln ln elmsln.dev http admin@elmsln.dev yes
 cd $HOME && source .bashrc
 


### PR DESCRIPTION
When I've tried installing, can't get the epel repo until you get the remi one. So swapped them in the installation order