### PR TITLE
#1298 Support Multiple Course Selection for Media Content

### DIFF
--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/elmsmedia.install
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/elmsmedia.install
@@ -197,7 +197,7 @@ function elmsmedia_update_7014(&$sandbox) {
 /**
  * Support for multiple course selection for media content.
  */
-function elmsmedia_update_7014(&$sandbox) {
+function elmsmedia_update_7015(&$sandbox) {
   features_revert_module('elmsmedia_audio');
   features_revert_module('elmsmedia_document');
   features_revert_module('elmsmedia_external_video');

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/elmsmedia.install
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/elmsmedia.install
@@ -193,3 +193,14 @@ function elmsmedia_update_7014(&$sandbox) {
   features_revert_module('elmsmedia_svg');
   features_revert_module('elmsmedia_video');
 }
+
+/**
+ * Support for multiple course selection for media content.
+ */
+function elmsmedia_update_7014(&$sandbox) {
+  features_revert_module('elmsmedia_audio');
+  features_revert_module('elmsmedia_document');
+  features_revert_module('elmsmedia_external_video');
+  features_revert_module('elmsmedia_feature');
+  features_revert_module('elmsmedia_image');
+}

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_audio/elmsmedia_audio.features.field_instance.inc
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_audio/elmsmedia_audio.features.field_instance.inc
@@ -76,6 +76,7 @@ function elmsmedia_audio_field_default_field_instances() {
   $field_instances['node-audio-field_cis_course_ref'] = array(
     'bundle' => 'audio',
     'default_value' => NULL,
+    'default_value_function' => '',
     'deleted' => 0,
     'description' => '',
     'display' => array(
@@ -116,6 +117,24 @@ function elmsmedia_audio_field_default_field_instances() {
     'label' => 'Course',
     'required' => 0,
     'settings' => array(
+      'authcache' => array(
+        'clients' => array(
+          'authcache_ajax' => array(
+            'status' => 1,
+            'weight' => 0,
+          ),
+        ),
+        'fallback' => 'cancel',
+        'lifespan' => 3600,
+        'perpage' => 0,
+        'peruser' => 1,
+        'status' => 0,
+      ),
+      'behaviors' => array(
+        'prepopulate' => array(
+          'status' => 0,
+        ),
+      ),
       'user_register_form' => FALSE,
     ),
     'widget' => array(

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_audio/elmsmedia_audio.info
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_audio/elmsmedia_audio.info
@@ -16,6 +16,7 @@ dependencies[] = og
 dependencies[] = options
 dependencies[] = strongarm
 dependencies[] = taxonomy
+dependencies[] = text
 features[ctools][] = ds:ds:1
 features[ctools][] = field_group:field_group:1
 features[ctools][] = strongarm:strongarm:1

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_document/elmsmedia_document.features.field_instance.inc
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_document/elmsmedia_document.features.field_instance.inc
@@ -14,6 +14,7 @@ function elmsmedia_document_field_default_field_instances() {
   $field_instances['node-document-field_cis_course_ref'] = array(
     'bundle' => 'document',
     'default_value' => NULL,
+    'default_value_function' => '',
     'deleted' => 0,
     'description' => '',
     'display' => array(
@@ -51,6 +52,24 @@ function elmsmedia_document_field_default_field_instances() {
     'label' => 'Course',
     'required' => 0,
     'settings' => array(
+      'authcache' => array(
+        'clients' => array(
+          'authcache_ajax' => array(
+            'status' => 1,
+            'weight' => 0,
+          ),
+        ),
+        'fallback' => 'cancel',
+        'lifespan' => 3600,
+        'perpage' => 0,
+        'peruser' => 1,
+        'status' => 0,
+      ),
+      'behaviors' => array(
+        'prepopulate' => array(
+          'status' => 0,
+        ),
+      ),
       'user_register_form' => FALSE,
     ),
     'widget' => array(

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_external_video/elmsmedia_external_video.features.field_instance.inc
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_external_video/elmsmedia_external_video.features.field_instance.inc
@@ -14,6 +14,7 @@ function elmsmedia_external_video_field_default_field_instances() {
   $field_instances['node-external_video-field_cis_course_ref'] = array(
     'bundle' => 'external_video',
     'default_value' => NULL,
+    'default_value_function' => '',
     'deleted' => 0,
     'description' => '',
     'display' => array(
@@ -75,6 +76,24 @@ function elmsmedia_external_video_field_default_field_instances() {
     'label' => 'Course',
     'required' => 0,
     'settings' => array(
+      'authcache' => array(
+        'clients' => array(
+          'authcache_ajax' => array(
+            'status' => 1,
+            'weight' => 0,
+          ),
+        ),
+        'fallback' => 'cancel',
+        'lifespan' => 3600,
+        'perpage' => 0,
+        'peruser' => 1,
+        'status' => 0,
+      ),
+      'behaviors' => array(
+        'prepopulate' => array(
+          'status' => 0,
+        ),
+      ),
       'user_register_form' => FALSE,
     ),
     'widget' => array(

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_external_video/elmsmedia_external_video.info
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_external_video/elmsmedia_external_video.info
@@ -18,6 +18,7 @@ dependencies[] = og
 dependencies[] = options
 dependencies[] = strongarm
 dependencies[] = taxonomy
+dependencies[] = text
 dependencies[] = video_embed_field
 features[ctools][] = ds:ds:1
 features[ctools][] = field_group:field_group:1

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_feature/elmsmedia_feature.features.field_base.inc
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_feature/elmsmedia_feature.features.field_base.inc
@@ -37,7 +37,7 @@ function elmsmedia_feature_field_default_field_bases() {
   // Exported field_base: 'field_cis_course_ref'.
   $field_bases['field_cis_course_ref'] = array(
     'active' => 1,
-    'cardinality' => 1,
+    'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_cis_course_ref',

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_feature/elmsmedia_feature.info
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_feature/elmsmedia_feature.info
@@ -18,6 +18,7 @@ dependencies[] = strongarm
 dependencies[] = svg_sanitizer
 dependencies[] = video_embed_field
 dependencies[] = view_mode_tab
+dependencies[] = views
 dependencies[] = views_content_cache
 dependencies[] = views_fluid_grid
 features[ctools][] = views:views_default:3.0

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_image/elmsmedia_image.features.field_instance.inc
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_image/elmsmedia_image.features.field_instance.inc
@@ -14,6 +14,7 @@ function elmsmedia_image_field_default_field_instances() {
   $field_instances['node-elmsmedia_image-field_cis_course_ref'] = array(
     'bundle' => 'elmsmedia_image',
     'default_value' => NULL,
+    'default_value_function' => '',
     'deleted' => 0,
     'description' => '',
     'display' => array(
@@ -117,6 +118,24 @@ function elmsmedia_image_field_default_field_instances() {
     'label' => 'Course',
     'required' => 0,
     'settings' => array(
+      'authcache' => array(
+        'clients' => array(
+          'authcache_ajax' => array(
+            'status' => 1,
+            'weight' => 0,
+          ),
+        ),
+        'fallback' => 'cancel',
+        'lifespan' => 3600,
+        'perpage' => 0,
+        'peruser' => 1,
+        'status' => 0,
+      ),
+      'behaviors' => array(
+        'prepopulate' => array(
+          'status' => 0,
+        ),
+      ),
       'user_register_form' => FALSE,
     ),
     'widget' => array(

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_video/elmsmedia_video.features.field_instance.inc
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_video/elmsmedia_video.features.field_instance.inc
@@ -92,6 +92,7 @@ function elmsmedia_video_field_default_field_instances() {
   $field_instances['node-video-field_cis_course_ref'] = array(
     'bundle' => 'video',
     'default_value' => NULL,
+    'default_value_function' => '',
     'deleted' => 0,
     'description' => '',
     'display' => array(
@@ -153,6 +154,24 @@ function elmsmedia_video_field_default_field_instances() {
     'label' => 'Course',
     'required' => 0,
     'settings' => array(
+      'authcache' => array(
+        'clients' => array(
+          'authcache_ajax' => array(
+            'status' => 1,
+            'weight' => 0,
+          ),
+        ),
+        'fallback' => 'cancel',
+        'lifespan' => 3600,
+        'perpage' => 0,
+        'peruser' => 1,
+        'status' => 0,
+      ),
+      'behaviors' => array(
+        'prepopulate' => array(
+          'status' => 0,
+        ),
+      ),
       'user_register_form' => FALSE,
     ),
     'widget' => array(

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_video/elmsmedia_video.info
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_video/elmsmedia_video.info
@@ -17,6 +17,7 @@ dependencies[] = og
 dependencies[] = options
 dependencies[] = strongarm
 dependencies[] = taxonomy
+dependencies[] = text
 features[ctools][] = ds:ds:1
 features[ctools][] = field_group:field_group:1
 features[ctools][] = strongarm:strongarm:1


### PR DESCRIPTION
<!--
Please make sure to read our contributing guidelines first. Please try to limit the scope, provide a general description of the changes.
-->

Fixes #

Media now supports multiple courses to be selected for what course it should go in. Files affected by this change feature override:

audio
document
external_video
feature
image