### PR TITLE
Vagrant now uses ubuntu 16.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # centos 7.2 - 64 bit
   #config.vm.box = "bradallenfisher/centos7"
   # primed centos 7.2 - 64 bit
-  config.vm.box = "elmsln/centos7"
+  config.vm.box = "bento/ubuntu-16.04"
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
   end
@@ -43,7 +43,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
   # run script as root
   config.vm.provision "shell",
-    args: "https://github.com/elmsln/elmsln.git 0.7.x https://github.com/elmsln/elmsln-config-vagrant.git",
+    args: "https://github.com/bradallenfisher/elmsln.git 0.7.x https://github.com/elmsln/elmsln-config-vagrant.git",
     path: "scripts/vagrant/handsfree-vagrant.sh"
 
   # run as the vagrant user

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
   # run script as root
   config.vm.provision "shell",
-    args: "https://github.com/bradallenfisher/elmsln.git 0.7.x https://github.com/elmsln/elmsln-config-vagrant.git",
+    args: "https://github.com/elmsln/elmsln.git 0.7.x https://github.com/elmsln/elmsln-config-vagrant.git",
     path: "scripts/vagrant/handsfree-vagrant.sh"
 
   # run as the vagrant user

--- a/scripts/install/handsfree/ubuntu16/ubuntu16-install.sh
+++ b/scripts/install/handsfree/ubuntu16/ubuntu16-install.sh
@@ -54,9 +54,6 @@ a2enconf php7.0-fpm
 a2enmod ssl rewrite headers
 pecl channel-update pecl.php.net
 
-pecl install yaml-2.0.0 && echo "extension=yaml.so" > /etc/php/7.0/mods-available/yaml.ini
-phpenmod yaml
-
 # install uploadprogress
 pecl install uploadprogress
 
@@ -88,6 +85,13 @@ groupadd elmsln
 # get base mysql tables established
 #mysql_install_db
 # run the handsfree installer that's the same for all deployments
+
+# Not sure why but run this at the end...
+apt-get install libyaml-dev -y
+yes '' | pecl install -f yaml-2.0.0
+echo "extension=yaml.so" > /etc/php/7.0/mods-available/yaml.ini
+phpenmod yaml
+service php7.0-fpm restart
 
 # kick off hands free deployment
 cd $HOME

--- a/scripts/install/handsfree/ubuntu16/ubuntu16-install.sh
+++ b/scripts/install/handsfree/ubuntu16/ubuntu16-install.sh
@@ -46,7 +46,7 @@ apt-get -y install apache2
 apt-get -y install sendmail uuid uuid-runtime curl policycoreutils unzip patch git nano gcc make mcrypt
 
 #install php
-apt-get -y install php php-fpm php-common php-mysql php-ldap php-cgi php-pear php-xml-parser php-curl php-gd php-cli php-fpm php-apcu php-dev php-mcrypt mcrypt
+apt-get -y install php php-fpm php-common php-mysql php-ldap php-cgi php-pear php-mbstring php-zip php-xml-parser php-curl php-gd php-cli php-fpm php-apcu php-dev php-mcrypt mcrypt
 a2enmod proxy_fcgi setenvif
 a2enconf php7.0-fpm
 

--- a/scripts/install/handsfree/ubuntu16/ubuntu16-install.sh
+++ b/scripts/install/handsfree/ubuntu16/ubuntu16-install.sh
@@ -26,7 +26,7 @@ start="$(timestamp)"
 # make sure we're up to date with 5.6 repos
 apt-get update -y
 
-# Needed to make sure that we have mcrypt which apparently is ok again. 
+# Needed to make sure that we have mcrypt which apparently is ok again.
 apt-get upgrade -y
 export DEBIAN_FRONTEND=noninteractive
 

--- a/scripts/vagrant/cleanup.sh
+++ b/scripts/vagrant/cleanup.sh
@@ -12,13 +12,17 @@ sudo bash /var/www/elmsln/scripts/utilities/harden-security.sh vagrant
 # disable varnish which the Cent 6.x image enables by default
 # this way when we're doing local development we don't get cached anything
 # port swap to not use varnish in local dev
-sudo sed -i 's/Listen 8080/Listen 80/g' /etc/httpd/conf/httpd.conf
-sudo sed -i 's/8080/80/g' /etc/httpd/conf.sites.d/*.conf
-sudo service varnish stop
-sudo /etc/init.d/httpd restart
-sudo /etc/init.d/mysqld restart
+#sudo sed -i 's/Listen 8080/Listen 80/g' /etc/httpd/conf/httpd.conf
+#sudo sed -i 's/8080/80/g' /etc/httpd/conf.sites.d/*.conf
+#sudo service varnish stop
+#sudo /etc/init.d/httpd restart
+#sudo /etc/init.d/mysqld restart
 # disable varnish from starting automatically on reboot
-sudo chkconfig varnish off
+#sudo chkconfig varnish off
+
+#service php7.0-fpm restart
+#service apache2 restart
+#service mysqld restart
 
 # Install front end stack in case users wish to develop with sass.
 #curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.32.0/install.sh | bash

--- a/scripts/vagrant/handsfree-vagrant.sh
+++ b/scripts/vagrant/handsfree-vagrant.sh
@@ -30,7 +30,7 @@ git checkout -b $branch
 git fetch --all
 git reset --hard origin/$branch
 cd $HOME
-bash /var/www/elmsln/scripts/install/handsfree/centos7/centos7-install.sh elmsln ln elmsln.local http admin@elmsln.local yes
+bash /var/www/elmsln/scripts/install/handsfree/ubuntu16/ubuntu16-install.sh elmsln ln elmsln.local http admin@elmsln.local yes
 cd $HOME && source .bashrc
 
 git clone $configrepo /var/www/elmsln-config-vagrant
@@ -48,9 +48,9 @@ cp /var/www/elmsln-config-vagrant/shared/drupal-7.x/settings/shared_settings.php
 # vagrant and core services on the VM starting correctly
 # when ever networking is screwed up
 echo '#!/bin/bash' >> /etc/profile.d/chkon.sh
-echo 'phpfpm=$(sudo /sbin/service php-fpm status)' >> /etc/profile.d/chkon.sh
+echo 'phpfpm=$(sudo /sbin/service php7.0-fpm status)' >> /etc/profile.d/chkon.sh
 echo 'mysql=$(sudo /sbin/service mysqld status)' >> /etc/profile.d/chkon.sh
-echo 'httpd=$(sudo /sbin/service httpd status)' >> /etc/profile.d/chkon.sh
+echo 'httpd=$(sudo /sbin/service apache2 status)' >> /etc/profile.d/chkon.sh
 # test for mysql
 echo 'if [[ $mysql == *"inactive (dead)"* ]]' >> /etc/profile.d/chkon.sh
 echo 'then' >> /etc/profile.d/chkon.sh
@@ -64,7 +64,7 @@ echo 'fi' >> /etc/profile.d/chkon.sh
 # test for phpfpm
 echo 'if [[ $phpfpm == *"inactive (dead)"* ]]' >> /etc/profile.d/chkon.sh
 echo 'then' >> /etc/profile.d/chkon.sh
-echo '  sudo /sbin/service php-fpm restart' >> /etc/profile.d/chkon.sh
+echo '  sudo /sbin/service php7.0-fpm restart' >> /etc/profile.d/chkon.sh
 echo 'fi' >> /etc/profile.d/chkon.sh
 
 # vagrant specific stuff
@@ -82,6 +82,7 @@ service httpd restart
 su - vagrant bash /var/www/elmsln/scripts/install/users/elmsln-admin-user.sh /home/vagrant
 
 sed -i '1i export PATH="/home/vagrant/.config/composer/vendor/bin:$PATH"' /home/vagrant/.bashrc
+sed -i '1i export PATH="/home/vagrant/.composer/vendor/bin:$PATH"' /home/vagrant/.bashrc
 
 # add vagrant to the elmsln group
 usermod -a -G elmsln vagrant
@@ -91,10 +92,10 @@ bash /var/www/elmsln/scripts/utilities/harden-security.sh vagrant
 
 # disable varnish this way when we're doing local development we don't get cached anything
 # port swap to not use varnish in local dev
-sed -i 's/Listen 8080/Listen 80/g' /etc/httpd/conf/httpd.conf
+//sed -i 's/Listen 8080/Listen 80/g' /etc/httpd/conf/httpd.conf
 
 service varnish stop
-service httpd restart
+service apache2 restart
 service mysqld restart
 
 # disable varnish from starting automatically on reboot

--- a/scripts/vagrant/handsfree-vagrant.sh
+++ b/scripts/vagrant/handsfree-vagrant.sh
@@ -92,7 +92,7 @@ bash /var/www/elmsln/scripts/utilities/harden-security.sh vagrant
 
 # disable varnish this way when we're doing local development we don't get cached anything
 # port swap to not use varnish in local dev
-//sed -i 's/Listen 8080/Listen 80/g' /etc/httpd/conf/httpd.conf
+#//sed -i 's/Listen 8080/Listen 80/g' /etc/httpd/conf/httpd.conf
 
 #service varnish stop
 service apache2 restart

--- a/scripts/vagrant/handsfree-vagrant.sh
+++ b/scripts/vagrant/handsfree-vagrant.sh
@@ -48,23 +48,23 @@ cp /var/www/elmsln-config-vagrant/shared/drupal-7.x/settings/shared_settings.php
 # vagrant and core services on the VM starting correctly
 # when ever networking is screwed up
 echo '#!/bin/bash' >> /etc/profile.d/chkon.sh
-echo 'phpfpm=$(sudo /sbin/service php7.0-fpm status)' >> /etc/profile.d/chkon.sh
-echo 'mysql=$(sudo /sbin/service mysqld status)' >> /etc/profile.d/chkon.sh
-echo 'httpd=$(sudo /sbin/service apache2 status)' >> /etc/profile.d/chkon.sh
+echo 'phpfpm=$(sudo /usr/sbin/service php7.0-fpm status)' >> /etc/profile.d/chkon.sh
+echo 'mysql=$(sudo /usr/sbin/service mysqld status)' >> /etc/profile.d/chkon.sh
+echo 'httpd=$(sudo /usr/sbin/service apache2 status)' >> /etc/profile.d/chkon.sh
 # test for mysql
 echo 'if [[ $mysql == *"inactive (dead)"* ]]' >> /etc/profile.d/chkon.sh
 echo 'then' >> /etc/profile.d/chkon.sh
-echo '  sudo /sbin/service mysqld restart' >> /etc/profile.d/chkon.sh
+echo '  sudo /usr/sbin/service mysqld restart' >> /etc/profile.d/chkon.sh
 echo 'fi' >> /etc/profile.d/chkon.sh
 # test for apache
 echo 'if [[ $httpd == *"inactive (dead)"* ]]' >> /etc/profile.d/chkon.sh
 echo 'then' >> /etc/profile.d/chkon.sh
-echo '  sudo /sbin/service apache2 restart' >> /etc/profile.d/chkon.sh
+echo '  sudo /usr/sbin/service apache2 restart' >> /etc/profile.d/chkon.sh
 echo 'fi' >> /etc/profile.d/chkon.sh
 # test for phpfpm
 echo 'if [[ $phpfpm == *"inactive (dead)"* ]]' >> /etc/profile.d/chkon.sh
 echo 'then' >> /etc/profile.d/chkon.sh
-echo '  sudo /sbin/service php7.0-fpm restart' >> /etc/profile.d/chkon.sh
+echo '  sudo /usr/sbin/service php7.0-fpm restart' >> /etc/profile.d/chkon.sh
 echo 'fi' >> /etc/profile.d/chkon.sh
 
 # vagrant specific stuff

--- a/scripts/vagrant/handsfree-vagrant.sh
+++ b/scripts/vagrant/handsfree-vagrant.sh
@@ -59,7 +59,7 @@ echo 'fi' >> /etc/profile.d/chkon.sh
 # test for apache
 echo 'if [[ $httpd == *"inactive (dead)"* ]]' >> /etc/profile.d/chkon.sh
 echo 'then' >> /etc/profile.d/chkon.sh
-echo '  sudo /sbin/service httpd restart' >> /etc/profile.d/chkon.sh
+echo '  sudo /sbin/service apache2 restart' >> /etc/profile.d/chkon.sh
 echo 'fi' >> /etc/profile.d/chkon.sh
 # test for phpfpm
 echo 'if [[ $phpfpm == *"inactive (dead)"* ]]' >> /etc/profile.d/chkon.sh

--- a/scripts/vagrant/handsfree-vagrant.sh
+++ b/scripts/vagrant/handsfree-vagrant.sh
@@ -77,7 +77,7 @@ drush @elmsln upwd admin --password=admin --y
 # enable devel everywhere
 drush @elmsln en devel --y
 # restart apache to frag some caches because of the different settings that changed inside
-service httpd restart
+service apache2 restart
 
 su - vagrant bash /var/www/elmsln/scripts/install/users/elmsln-admin-user.sh /home/vagrant
 
@@ -94,9 +94,9 @@ bash /var/www/elmsln/scripts/utilities/harden-security.sh vagrant
 # port swap to not use varnish in local dev
 //sed -i 's/Listen 8080/Listen 80/g' /etc/httpd/conf/httpd.conf
 
-service varnish stop
+#service varnish stop
 service apache2 restart
 service mysqld restart
 
 # disable varnish from starting automatically on reboot
-chkconfig varnish off
+#chkconfig varnish off

--- a/scripts/vagrant/handsfree-vagrant.sh
+++ b/scripts/vagrant/handsfree-vagrant.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # hands free installer for vagrant environment based on cloud deployment 1liners
-yes | yum -y install git
+yes | apt-get install git
 
 if [ -z $1 ]; then
   repo='https://github.com/elmsln/elmsln.git'


### PR DESCRIPTION
Here goes nothing...

If I have access to the docs I am not sure how to edit. But https://elmsln.readthedocs.io/en/latest/development/Vagrant-Step-by-Step-setup/ needs to be edited to reflect new minimum versions of Vagrant and VirtualBox

Vagrant = 1.9.1
VirtualBox = 5.1.10

