### PR TITLE
tweaks to mooc toolbar.

### DIFF
--- a/core/dslmcode/profiles/mooc-7.x-1.x/themes/mooc_foundation_access/css/mooc_styles.css
+++ b/core/dslmcode/profiles/mooc-7.x-1.x/themes/mooc_foundation_access/css/mooc_styles.css
@@ -166,7 +166,7 @@
 }
 
 a.mooc-helper-toc {
-  font-size: 1rem;
+  font-size: .8rem;
   border-bottom: 2px solid black;
   text-align: center;
   padding: 0 0.5rem;
@@ -328,7 +328,7 @@ a.book-sibling-parent-pagination {
   overflow: hidden;
   text-overflow: ellipsis;
   border: none;
-  font-size: 1rem;
+  font-size: .8rem;
   font-weight: bold;
 }
 


### PR DESCRIPTION
Request to bump to the font-size down a hair to allow more room for the page titles.

## Before
![screen shot 2017-05-12 at 9 16 38 am](https://cloud.githubusercontent.com/assets/3428964/25999671/080dcc1e-36f4-11e7-85f3-0ea8bbe1f4c2.png)

## After
![screen shot 2017-05-12 at 9 16 26 am](https://cloud.githubusercontent.com/assets/3428964/25999679/10a21218-36f4-11e7-847c-3bf5ca21d736.png)
