### PR TITLE
Mooc nav icons overlay text #2005

### DIFF
--- a/core/dslmcode/profiles/mooc-7.x-1.x/themes/mooc_foundation_access/css/mooc_styles.css
+++ b/core/dslmcode/profiles/mooc-7.x-1.x/themes/mooc_foundation_access/css/mooc_styles.css
@@ -71,7 +71,7 @@
   position: absolute;
   font-size: 1.3rem;
   line-height: 2.4rem;
-  margin: 0 0 0 -.4rem;
+  margin: 0 0 0 -1rem;
   padding: 0 0 0 0.1rem;
   height: 2.4rem;
   width: 1rem;


### PR DESCRIPTION
fixes: #2005 

![screen shot 2017-05-16 at 9 47 51 am](https://cloud.githubusercontent.com/assets/3428964/26109871/9459dbf4-3a1e-11e7-9ee6-48af27239c8b.png)
