### PR TITLE
Gitbook Auto advance

### DIFF
--- a/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_helper_book_nav/mooc_helper_book_nav.module
+++ b/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_helper_book_nav/mooc_helper_book_nav.module
@@ -23,8 +23,8 @@ function mooc_helper_book_nav_node_view($node, $view_mode, $langcode) {
   // ensure this only happens for node's viewed in books
   // make sure we are viewing a book
   if (arg(0) == 'node' && $view_mode == 'full' && isset($node->book)) {
-    // make sure that the node body or field description is empty
-    if (isset($node->body) && empty($node->body['und'][0]['value']) || isset($node->field_git_description) && empty($node->field_git_description)) {
+    // if the node body is empty or we are on a gitbook page
+    if (isset($node->body) && empty($node->body['und'][0]['value']) || $node->type == 'git_book') {
       $next = book_next($node->book);
       // ensure we have a next item and it's in this one
       if ($next && $node->book['mlid'] == $next['plid']) {

--- a/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_helper_book_nav/mooc_helper_book_nav.module
+++ b/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_helper_book_nav/mooc_helper_book_nav.module
@@ -21,15 +21,21 @@ function mooc_helper_book_nav_page_build(&$page) {
  */
 function mooc_helper_book_nav_node_view($node, $view_mode, $langcode) {
   // ensure this only happens for node's viewed in books
-  if (arg(0) == 'node' && $view_mode == 'full' && isset($node->book) && isset($node->body) && empty($node->body['und'][0]['value'])) {
-    $next = book_next($node->book);
-    // ensure we have a next item and it's in this one
-    if ($next && $node->book['mlid'] == $next['plid']) {
-      if (entity_access('update', 'node', $node)) {
-        drupal_set_message(t('This page is empty, so students will automatically be taken to the next page. You have not been since you can edit this content.'), 'status', FALSE);
-      }
-      else {
-        drupal_goto($next['link_path']);
+  // make sure we are viewing a book
+  if (arg(0) == 'node' && $view_mode == 'full' && isset($node->book)) {
+    // make sure that the node body or field description is empty
+    if (isset($node->body) && empty($node->body['und'][0]['value']) || isset($node->field_git_description) && empty($node->field_git_description)) {
+      $next = book_next($node->book);
+      // ensure we have a next item and it's in this one
+      if ($next && $node->book['mlid'] == $next['plid']) {
+        if (entity_access('update', 'node', $node)) {
+          // if the user is a content author let them know that this page would be automatically redirected
+          drupal_set_message(t('This page is empty, so students will automatically be taken to the next page. You have not been since you can edit this content.'), 'status', FALSE);
+        }
+        else {
+          // if the user is a standard user then take them to the next book page
+          drupal_goto($next['link_path']);
+        }
       }
     }
   }


### PR DESCRIPTION
The auto advance will now check the current page is of type book with an empty body field OR of type git_book.  Both will result in true and advance the page for a person who doesn't have permission to edit the page.

Fixes #2007 
