### PR TITLE
Citation field input wraps instead of displaying inline 

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/css/tweaks.css
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/css/tweaks.css
@@ -1693,7 +1693,7 @@ cite, .image__cite, .image--lightboxed__cite {
   max-width: 100%;
 }
 
-cite p, .image__cite p, .image--lightboxed__cite p {
+cite p, .image .image__cite p, .image--lightboxed__cite p {
   font-size: .8rem;
   max-width: 100%;
 }


### PR DESCRIPTION

I added .image selector to tweaks.css line 1696; this allows 'citation field' the ability to display inline.


Fixes #2013 
