### PR TITLE
Add hyperlink functionality to simple text format #2012 -- Pull request

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/elmsln_simple_filter/elmsln_simple_filter.features.filter.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/elmsln_simple_filter/elmsln_simple_filter.features.filter.inc
@@ -27,6 +27,13 @@ function elmsln_simple_filter_filter_default_formats() {
           'filter_html_nofollow' => 0,
         ),
       ),
+      'filter_url' => array(
+        'weight' => -5,
+        'status' => 1,
+        'settings' => array(
+          'filter_url_length' => 72,
+        ),
+      ),
       'filter_autop' => array(
         'weight' => 0,
         'status' => 1,


### PR DESCRIPTION
Checked "Convert URLs into links" for Simple text format and exported into feature. This should resolve the feature request from issue 2012 below.

Fixes #
2012 (https://github.com/elmsln/elmsln/issues/2012)

Please let me know how to better submit pull requests (tried to follow contributing.md) in the future.

Thanks.

-Nate