### PR TITLE
Update docs frontend paths broken

### DIFF
--- a/docs/development/front-end/Fonts.md
+++ b/docs/development/front-end/Fonts.md
@@ -1,4 +1,4 @@
 # Fonts
 ELMSLN utilizes the Material design specification and the Google Material font set. You can search through that here — https://design.google.com/icons/
 
-ELMSLN also has its own icon font for different system icons and other goodies. You can review what those are through our reference set — https://rawgit.com/elmsln/elmsln/master/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/fonts/elmsln/icons-reference.html.
+ELMSLN also has its own icon font for different system icons and other goodies. You can review what those are through our reference set — https://rawgit.com/elmsln/elmsln/master/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/fonts/elmsln/icons-reference.html

--- a/docs/development/front-end/Fonts.md
+++ b/docs/development/front-end/Fonts.md
@@ -1,4 +1,4 @@
 # Fonts
 ELMSLN utilizes the Material design specification and the Google Material font set. You can search through that here — https://design.google.com/icons/
 
-ELMSLN also has its own icon font for different system icons and other goodies. You can review what those are through our reference set — https://rawgit.com/elmsln/elmsln/0.5.x/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/fonts/elmsln/icons-reference.html
+ELMSLN also has its own icon font for different system icons and other goodies. You can review what those are through our reference set — https://rawgit.com/elmsln/elmsln/master/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/fonts/elmsln/icons-reference.html.

--- a/docs/development/front-end/Front-End-Development-Workflow.md
+++ b/docs/development/front-end/Front-End-Development-Workflow.md
@@ -9,7 +9,7 @@
 2. `git clone --recursive https://github.com/elmsln/elmsln-developer.git elmsln`
 3. `cd elmsln/system`
 1. `git pull origin master` (or 1.x.x or whatever branch you want)
-4. `cd core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/`
+4. `cd core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/legacy`
 5. `npm install`
 6. `bower install`
 7. `grunt`

--- a/docs/development/front-end/Styleguide.md
+++ b/docs/development/front-end/Styleguide.md
@@ -1,1 +1,1 @@
-https://cdn.rawgit.com/heyMP/elmsln/master/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/styleguide/index.html
+https://cdn.rawgit.com/elmsln/elmsln/master/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/legacy/styleguide/index.html


### PR DESCRIPTION
In reading through the front-end docs, I noticed a couple of links that were 404ing & and path that needed to be updated. These are very small changes to the documentation.