### PR TITLE
H5P can't download/upload .h5p files w/o updated packages

### DIFF
--- a/scripts/install/handsfree/ubuntu16/ubuntu16-install.sh
+++ b/scripts/install/handsfree/ubuntu16/ubuntu16-install.sh
@@ -46,7 +46,7 @@ apt-get -y install apache2
 apt-get -y install sendmail uuid uuid-runtime curl policycoreutils unzip patch git nano gcc make mcrypt
 
 #install php
-apt-get -y install php php-fpm php-common php-mysql php-ldap php-cgi php-pear php-mbstring php-zip php-xml-parser php-curl php-gd php-cli php-fpm php-apcu php-dev php-mcrypt mcrypt
+apt-get -y install php php-fpm php-common php-mysql php-ldap php-cgi php-pear php7.0-mbstring php7.0-zip php-xml-parser php-curl php-gd php-cli php-fpm php-apcu php-dev php-mcrypt mcrypt
 a2enmod proxy_fcgi setenvif
 a2enconf php7.0-fpm
 


### PR DESCRIPTION
Couldn't install h5p libraries at http://media.elmsln.local/admin/content/h5p. zip & mbstring packages were missing. 

I can confirm that a clean vagrant up (with this commit) allows for installing h5p libraries. Reviewing all of the packages would be a good idea, but it is beyond me.

Fixes #1911 
