### PR TITLE
Hide horizontal scrollbar on short pages

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/legacy/js/app.js
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/legacy/js/app.js
@@ -70,7 +70,7 @@ var clipboardjs = require('./components/clipboardjs.js');
       $(".accessibility-content-toggle").hide();
     }
   };
-  Drupal.settings.progressScroll ={scroll:0, total:0, scrollPercent:0};
+  Drupal.settings.progressScroll ={scroll:0, total:0, scrollPercent:0, windowDividedByDocumentPercent:($(window).height() / $(document).height()) * 100,};
   // sticky stuff
   Drupal.behaviors.stickyStuff = {
     attach: function (context, settings) {
@@ -81,18 +81,22 @@ var clipboardjs = require('./components/clipboardjs.js');
   // Page Scrolling Progress Bar
   Drupal.progressScroll = {
     attach: function (context, settings) {
-      // don't use the top bar in the calculation
-      if ($(window).height() > $("#etb-tool-nav .inner-wrap", context)[0].offsetHeight) {
-        Drupal.settings.progressScroll.scroll = $(window).scrollTop();
-        Drupal.settings.progressScroll.total = $("#etb-tool-nav", context)[0].offsetTop;
+      // Only show the progressScoll if the height of the browser viewport / height of the html document is less than or equal to 50%.
+      // (The page is at least 2x the height of the monitor.)
+      if (Drupal.settings.progressScroll.windowDividedByDocumentPercent <= 50) {
+        // don't use the top bar in the calculation
+        if ($(window).height() > $("#etb-tool-nav .inner-wrap", context)[0].offsetHeight) {
+          Drupal.settings.progressScroll.scroll = $(window).scrollTop();
+          Drupal.settings.progressScroll.total = $("#etb-tool-nav", context)[0].offsetTop;
+        }
+        else {
+          Drupal.settings.progressScroll.scroll = $(window).scrollTop() - $("#etb-tool-nav", context)[0].offsetTop;
+          Drupal.settings.progressScroll.total = $("#etb-tool-nav .inner-wrap", context)[0].offsetHeight - $(window).height();
+        }
+        Drupal.settings.progressScroll.scrollPercent = (Drupal.settings.progressScroll.scroll / Drupal.settings.progressScroll.total)*100;
+        // set percentage of the meter to the scroll down the screen
+        $(".page-scroll.progress .meter", context).css({"width": Drupal.settings.progressScroll.scrollPercent+"%"});
       }
-      else {
-        Drupal.settings.progressScroll.scroll = $(window).scrollTop() - $("#etb-tool-nav", context)[0].offsetTop;
-        Drupal.settings.progressScroll.total = $("#etb-tool-nav .inner-wrap", context)[0].offsetHeight - $(window).height();
-      }
-      Drupal.settings.progressScroll.scrollPercent = (Drupal.settings.progressScroll.scroll / Drupal.settings.progressScroll.total)*100;
-      // set percentage of the meter to the scroll down the screen
-      $(".page-scroll.progress .meter", context).css({"width": Drupal.settings.progressScroll.scrollPercent+"%"});
     }
   };
 

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/legacy/js/dist/app.js
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/legacy/js/dist/app.js
@@ -71,7 +71,7 @@ var clipboardjs = require('./components/clipboardjs.js');
       $(".accessibility-content-toggle").hide();
     }
   };
-  Drupal.settings.progressScroll ={scroll:0, total:0, scrollPercent:0};
+  Drupal.settings.progressScroll ={scroll:0, total:0, scrollPercent:0, windowDividedByDocumentPercent:($(window).height() / $(document).height()) * 100,};
   // sticky stuff
   Drupal.behaviors.stickyStuff = {
     attach: function (context, settings) {
@@ -84,18 +84,22 @@ var clipboardjs = require('./components/clipboardjs.js');
   // Page Scrolling Progress Bar
   Drupal.progressScroll = {
     attach: function (context, settings) {
-      // don't use the top bar in the calculation
-      if ($(window).height() > $("#etb-tool-nav .inner-wrap", context)[0].offsetHeight) {
-        Drupal.settings.progressScroll.scroll = $(window).scrollTop();
-        Drupal.settings.progressScroll.total = $("#etb-tool-nav", context)[0].offsetTop;
+      // Only show the progressScoll if the height of the browser viewport / height of the html document is less than or equal to 50%.
+      // (The page is at least 2x the height of the monitor.)
+      if (Drupal.settings.progressScroll.windowDividedByDocumentPercent <= 50) {
+        // don't use the top bar in the calculation
+        if ($(window).height() > $("#etb-tool-nav .inner-wrap", context)[0].offsetHeight) {
+          Drupal.settings.progressScroll.scroll = $(window).scrollTop();
+          Drupal.settings.progressScroll.total = $("#etb-tool-nav", context)[0].offsetTop;
+        }
+        else {
+          Drupal.settings.progressScroll.scroll = $(window).scrollTop() - $("#etb-tool-nav", context)[0].offsetTop;
+          Drupal.settings.progressScroll.total = $("#etb-tool-nav .inner-wrap", context)[0].offsetHeight - $(window).height();
+        }
+        Drupal.settings.progressScroll.scrollPercent = (Drupal.settings.progressScroll.scroll / Drupal.settings.progressScroll.total)*100;
+        // set percentage of the meter to the scroll down the screen
+        $(".page-scroll.progress .meter", context).css({"width": Drupal.settings.progressScroll.scrollPercent+"%"});
       }
-      else {
-        Drupal.settings.progressScroll.scroll = $(window).scrollTop() - $("#etb-tool-nav", context)[0].offsetTop;
-        Drupal.settings.progressScroll.total = $("#etb-tool-nav .inner-wrap", context)[0].offsetHeight - $(window).height();
-      }
-      Drupal.settings.progressScroll.scrollPercent = (Drupal.settings.progressScroll.scroll / Drupal.settings.progressScroll.total)*100;
-      // set percentage of the meter to the scroll down the screen
-      $(".page-scroll.progress .meter", context).css({"width": Drupal.settings.progressScroll.scrollPercent+"%"});
     }
   };
 


### PR DESCRIPTION
I added new setting to check the window vs document heights. The if statement is used to determine if the scrollbar should be shown on the screen. 

Currently 50 is the magic number. This means that a page that is twice as long as the monitor display will show the scrollbar. 50 could be changed to 33.3 if the scrollbar should only be shown on pages that are three times longer than the monitor height.

- legacy/js/dist/app.js is the code that is run. I added code to both files in case I'm missing something.

Fixes #2001
