### PR TITLE
Added Wildcard Routes to Webcomponents module

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/webcomponents/README.md
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/webcomponents/README.md
@@ -55,31 +55,54 @@ You can turbo charge you single page app development workflows with Drupal and t
 {
   "name": "phone-book",
   "short_name": "phone-book",
-  "title": "Phone book",
   "description": "An app for loading phone numbers and making them searchable",
   "start_url": "/",
   "display": "standalone",
-  "drupal": {
+  "title": "Phone Book App",
+  "app_integration": {
     "menu": {
       "menu_name": "main-menu",
       "weight": 10
     },
-    "data": {
-      "callback": "_custom_phonebook_module_data",
-      "property": "source-path"
+    "endpoints": {
+      "api/numbers": {
+        "callback": "_custom_phonebook_module_numbers",
+        "property": "source-path"
+      }
+      "api/numbers/%": {
+        "callback": "_custom_phonebook_module_number"
+        "property": "source-path"
+      },
+      "api/numbers/%/call": {
+        "callback": "_custom_phonebook_module_number_call"
+        "property": "source-path"
+      },
+      "api/numbers/%/text": {
+        "callback": "_custom_phonebook_module_number_text"
+        "property": "source-path"
+      }
     }
   }
 }
 ```
 - Note that menu will provide the ability for the app to be visible in Drupal's menu system, in this example the main menu. Weight is the order it falls in that menu.
-- If you need a data callback to power your app, then the `data` property is for you. `data` has two parameters, callback and property.
+- If you need a data callback to power your app, then the `endpoints` property is for you. `endpoints` has two parameters, callback and property.
   - `callback` is the php function to call in order to return the data needed. If all goes well, this is probably the most "drupal" specific stuff you have to do today.
-  - property is the property your webcomponent is looking for data from. For example. if you have a one page tag called `<phone-book>` and phone-book gets data by using `source-path="whatever.json"` then property would be `source-path`.
+  - `property` is the property your webcomponent is looking for data from. For example. if you have a one page tag called `<phone-book>` and phone-book gets data by using `source-path="whatever.json"` then property would be `source-path`.
+  - Wildcard routes are supported by using the `%` placeholder when defining your routes. You can access the wildcard value via the `arg()` function your defined callback. For instance, if your route is `api/numbers/%/call` then you would access
+  the wildcard value in your function like so:
+  ```
+  function _custom_phonebook_module_number_call($machine_name, $path, $params, $args) {
+    $args = arg();
+    $number = arg[2]
+    ...
+  }
+  ```
 - Now when you clear your caches and have these files pushed up, the following will happen automatically!
 1. A permission called `access phone-book app` will be created
 2. A menu path called `apps/phone-book` will be created and will load your element if accessed
 3. A menu item called "Phone book" will show up in the main menu that links to `apps/phone-book`
-4. A menu callback path called `apps/phone-book/data` will be created and will return your data delivered by the function `_custom_phonebook_module_data`
+4. For each `endpoint` you have defined menu callback paths will be created and will return your data delivered by the function you've specified. So `apps/phone-book/api/numbers` will be created and fed data via `_custom_phonebook_module_numbers`.
 5. You will be incredibly happy with how little Drupal specific work your front-end designer just had to do!
 
 ### A note on data returned by that PHP function

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/webcomponents/modules/webcomponents_app/webcomponents_app.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/webcomponents/modules/webcomponents_app/webcomponents_app.module
@@ -271,9 +271,39 @@ function _webcomponents_app_load_app_data($machine_name = NULL, $debug = FALSE) 
     // this ensures that apps/machine-name get shifted off
     array_shift($args);
     array_shift($args);
-    // @todo this will need to account for wildcards which it currently can't
-    // match accurately and pass down
-    $endpointpath = implode('/', $args);
+    // match the route that was specified in $app['endpoints']
+    $endpointpath = NULL;
+    if (isset($app['endpoints'])) {
+      foreach ($app['endpoints'] as $path => $endpoint) {
+        // we're going to compare the args array and the endpoint.
+        // to do this we are going to convert the path to an array.
+        $path_ary = explode('/', $path);
+        // see if args and path are the same length
+        if (count($path_ary) == count($args)) {
+          // see if there are any differences between the two
+          $ary_diff = array_diff($path_ary, $args);
+          // if no differences then we found the path
+          if (!$ary_diff) {
+            $endpointpath = $path;
+          }
+          // if there is a difference in the path but the only differences
+          // are wildcards then it's a match
+          else {
+            $mismatch = false;
+            foreach ($ary_diff as $diff) {
+              if ($diff != '%') {
+                $mismatch = true;
+              }
+            }
+            // if we went through the diffs and there were no
+            // matches other than % then it's a match
+            if (!$mismatch) {
+              $endpointpath = $path;
+            }
+          }
+        }
+      }
+    }
     // make sure the machine name and the data callback both exist
     if (!empty($machine_name) && !empty($app) && isset($app['endpoints']) && function_exists($app['endpoints'][$endpointpath]['callback'])) {
       $params = filter_var_array($_GET, FILTER_SANITIZE_STRING);


### PR DESCRIPTION
Fixes #2079 

When the `_webcomponents_app_load_app_data` function is attempting to find the matching path, it will treat routes defined with the `%` placeholder as wildcard or dynamic routes.

So if it's evaluating the path `apps/phone-book/api/numbers/555-5555` it will match it to the `api/numbers/%` route that was defined in the apps `endpoints` object within the manifest.json file.