### PR TITLE
Add Gitbook sync feature 2009

### DIFF
--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/README.md
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/README.md
@@ -28,6 +28,50 @@ Take that zip file, and put it's contents into a folder called "gitphp" in your 
 Also, you need to make sure your Drupal site has write access to your private directory. This is where it will store the
 git repository.
 
+## Giving Apache the ability to push to gitbook remote repos
+
+If you are going to enable the `push` option in your gitbook, you need to make sure that apache can make push new commits to your
+remote repo. To do that you need to create an ssh key for apache.
+
+### Create an ssh key for apache user
+
+Create the ssh key for apache. In this example the apache user is `www-data` but that might be `apache` or `apache2` depending on your OS.
+
+```
+cd /var/www
+mkdir .ssh
+sudo chown -R www-data .ssh
+sudo -u www-data ssh-keygen -t rsa
+```
+
+Now that you have create the ssh key for apache, add the public key located at `/var/www/.ssh/id_rsa.pub` to your remote repo's list of allowed keys.
+
+## Drush commands
+
+Here are a few drush commands that help maintaing gitbooks.
+
+### Create book
+
+With `git-book-create` you can easily set up a gitbook. Give it a repo url, the machine name of the parser that should process it, and the name of the branch you want to check out. You can also use the `--push` option to set up the auto push option.
+
+After running this command, you might need to clean up permissions. Make sure that apache owns the directory of the git book repo.
+
+```
+git-book-create [repo_url] [parser_name] [branch_to_checkout]
+```
+
+### Get repo status 
+
+```
+git-book-status [book_name]
+```
+
+### Sync and update book
+
+```
+git-book-sync [book_name]
+```
+
 ## Roadmap
 Future plans are for synchronization as well as ability to push changes back to git repo (though this assumes the server
 is authorized to do so).

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
@@ -97,11 +97,12 @@ function drush_git_book_sync($name) {
  * Callback for command git-book-status
  */
 function drush_git_book_status($name) {
-  $books = _git_book_get_books_by_name($name);
+  $book = _git_book_drush_get_book_by_name($name);
 }
 
 /**
- * Helper function to retrieve a single book by name
+ * Helper function to retrieve a single book by name. Uses drush options to allow
+ * the user to select which book they want.
  * @return  mixed    Returns book object or false if no book was found.
  */
 function _git_book_drush_get_book_by_name($name) {

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
@@ -29,7 +29,7 @@ function git_book_drush_command() {
     'aliases' => array('gcs'),
     'description' => dt('Sync existing git book'),
     'arguments' => array(
-      'node_id' => 'git_book node id'
+      'name' => 'unique name of the gitbook.'
     ),
   ); 
 
@@ -40,36 +40,71 @@ function git_book_drush_command() {
  * Callback for command git-book-create.
  */
 function drush_git_book_create($repo_url, $parser, $branch) {
-  $node = new stdClass();
-  $node->type = 'git_book';
-  node_object_prepare($node);
-  $node->language = LANGUAGE_NONE;
-  $node->uid = 1;
-  $node->status = 1;
-  $node->promote = 0;
-  $node->revision = 1;
   // make a path out of the repo name
   $tmp = explode('/', str_replace('.git', '', $repo_url));
   $title = array_pop($tmp);
-  $node->title = $title;
-  // set the git repo
-  $node->field_git_repo[LANGUAGE_NONE][0]['value'] = $repo_url;
-  $node->field_git_parser[LANGUAGE_NONE][0]['value'] = $parser;
-  $node->field_git_branch[LANGUAGE_NONE][0]['value'] = $branch;
-  // save which will kick off processing of the node
-  node_save($node);
-  drush_print(dt('git book @repo_url successfully imported as @title', array('@repo_url' => $repo_url, '@title' => $title)));
+  $query = new EntityFieldQuery();
+  $entities = $query->entityCondition('entity_type', 'node')
+    ->propertyCondition('type', 'git_book')
+    ->propertyCondition('title', $title)
+    ->execute();
+  if (empty($entities['node'])) {
+    $node = new stdClass();
+    $node->type = 'git_book';
+    node_object_prepare($node);
+    $node->language = LANGUAGE_NONE;
+    $node->title = $title;
+    $node->uid = 1;
+    $node->status = 1;
+    $node->promote = 0;
+    $node->revision = 1;
+    // set the git repo
+    $node->field_git_repo[LANGUAGE_NONE][0]['value'] = $repo_url;
+    $node->field_git_parser[LANGUAGE_NONE][0]['value'] = $parser;
+    $node->field_git_branch[LANGUAGE_NONE][0]['value'] = $branch;
+    // save which will kick off processing of the node
+    node_save($node);
+    drush_print(dt('git book @repo_url successfully imported as @title', array('@repo_url' => $repo_url, '@title' => $title)));
+  }
+  else {
+    drush_print(dt('A gitbook with the name @title already exists.', array('@title' => $title)));
+  }
 }
 
 /**
  * Callback for command git-book-sync
  */
-function drush_git_book_sync($nid) {
-  $node = node_load($nid);
-  // make sure it\s a gitbook node
-  if (isset($node->type) && $node->type == 'git_book') {
-    // get the gitbook outline
-    $path = _git_book_get_path($node);
-    git_book_gb_git_book_parse($path, $node);
+function drush_git_book_sync($name) {
+  $selected_node = NULL;
+  $query = new EntityFieldQuery();
+  $entities = $query->entityCondition('entity_type', 'node')
+    ->propertyCondition('type', 'git_book')
+    ->propertyCondition('title', $name)
+    ->execute();
+  if (!empty($entities['node'])) {
+    $nodes = entity_load('node', array_keys($entities['node']));
+    // if there is only one node then use that as the selected node
+    if (count($nodes) == 1) {
+      $selected_node = array_pop($nodes);
+    }
+    // if there is more than one node then we need to propmpt the user
+    // to choose.
+    else {
+      foreach ($nodes as $node) {
+        $drush_options[$node->nid] = $node->nid;
+      }
+      if (count($drush_options) > 1) {
+        $nid = drush_choice($drush_options, dt('Multple books with that name found. Which git book node would you like to update?'), '!value');
+        $selected_node = $nodes[$nid];
+      }
+    }
+  }
+  // if we had a new selected node 
+  if ($selected_node) {
+    $path = _git_book_get_path($selected_node);
+    git_book_gb_git_book_parse($path, $selected_node);
+  }
+  else {
+    drush_print(dt('Book not found.'));
   }
 }

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
@@ -25,7 +25,6 @@ function git_book_drush_command() {
     ),
     'options' => array(
       'push' => 'Boolean to set the repo to push on node changes.',
-      'push_branch' => 'Specify a different branch to push your changes to.',
     ), 
   );
   $commands['git-book-sync'] = array(
@@ -53,7 +52,7 @@ function git_book_drush_command() {
 function drush_git_book_create($repo_url, $parser, $branch) {
   // get the push option
   $push = drush_get_option('push', FALSE);
-  $push_branch = drush_get_option('push_branch', '');
+  $push = ($push ? 1 : 0);
   // make a path out of the repo name
   $tmp = explode('/', str_replace('.git', '', $repo_url));
   $title = array_pop($tmp);
@@ -77,7 +76,6 @@ function drush_git_book_create($repo_url, $parser, $branch) {
     $node->field_git_parser[LANGUAGE_NONE][0]['value'] = $parser;
     $node->field_git_branch[LANGUAGE_NONE][0]['value'] = $branch;
     $node->field_git_push[LANGUAGE_NONE][0]['value'] = $push;
-    $node->field_git_push_branch[LANGUAGE_NONE][0]['value'] = $push_branch;
     // save which will kick off processing of the node
     node_save($node);
     drush_print(dt('git book @repo_url successfully imported as @title', array('@repo_url' => $repo_url, '@title' => $title)));

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
@@ -76,16 +76,10 @@ function drush_git_book_create($repo_url, $parser, $branch) {
  */
 function drush_git_book_sync($name) {
   $selected_node = NULL;
-  $query = new EntityFieldQuery();
-  $entities = $query->entityCondition('entity_type', 'node')
-    ->propertyCondition('type', 'git_book')
-    ->propertyCondition('title', $name)
-    ->execute();
-  if (!empty($entities['node'])) {
-    $nodes = entity_load('node', array_keys($entities['node']));
-    // if there is only one node then use that as the selected node
-    if (count($nodes) == 1) {
-      $selected_node = array_pop($nodes);
+  $books = _git_book_get_books_by_name($name);
+  if ($books && !empty($books)) {
+    if (count($books) == 1) {
+      $selected_node = array_pop($books);
     }
     // if there is more than one node then we need to propmpt the user
     // to choose.

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
@@ -35,13 +35,6 @@ function git_book_drush_command() {
       'name' => 'unique name of the gitbook.'
     ),
   );
-  $commands['git-book-status'] = array(
-    'callback' => 'drush_git_book_status',
-    'description' => dt('Get the current status of a gitbook.'),
-    'arguments' => array(
-      'name' => 'unique name of the gitbook.'
-    ),
-  ); 
 
   return $commands;
 }
@@ -110,18 +103,6 @@ function drush_git_book_sync($name) {
   }
   else {
     drush_print(dt('Book not found.'));
-  }
-}
-
-/**
- * Callback for command git-book-status
- */
-function drush_git_book_status($name) {
-  $book = _git_book_drush_get_book_by_name($name);
-  if ($book) {
-    $repo = _git_book_get_repo($book);
-    $status = _git_book_get_status($repo);
-    drush_print($status);
   }
 }
 

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
@@ -23,6 +23,10 @@ function git_book_drush_command() {
       'parser' => 'parser machine name to use',
       'branch' => 'branch to checkout'
     ),
+    'options' => array(
+      'push' => 'Boolean to set the repo to push on node changes.',
+      'push_branch' => 'Specify a different branch to push your changes to.',
+    ), 
   );
   $commands['git-book-sync'] = array(
     'callback' => 'drush_git_book_sync',
@@ -47,6 +51,9 @@ function git_book_drush_command() {
  * Callback for command git-book-create.
  */
 function drush_git_book_create($repo_url, $parser, $branch) {
+  // get the push option
+  $push = drush_get_option('push', FALSE);
+  $push_branch = drush_get_option('push_branch', '');
   // make a path out of the repo name
   $tmp = explode('/', str_replace('.git', '', $repo_url));
   $title = array_pop($tmp);
@@ -69,6 +76,8 @@ function drush_git_book_create($repo_url, $parser, $branch) {
     $node->field_git_repo[LANGUAGE_NONE][0]['value'] = $repo_url;
     $node->field_git_parser[LANGUAGE_NONE][0]['value'] = $parser;
     $node->field_git_branch[LANGUAGE_NONE][0]['value'] = $branch;
+    $node->field_git_push[LANGUAGE_NONE][0]['value'] = $push;
+    $node->field_git_push_branch[LANGUAGE_NONE][0]['value'] = $push_branch;
     // save which will kick off processing of the node
     node_save($node);
     drush_print(dt('git book @repo_url successfully imported as @title', array('@repo_url' => $repo_url, '@title' => $title)));
@@ -86,7 +95,20 @@ function drush_git_book_sync($name) {
   $book = _git_book_drush_get_book_by_name($name);
   if ($book) {
     $path = _git_book_get_path($book);
-    git_book_gb_git_book_parse($path, $book);
+    // make sure we have a branch to pull from
+    if (isset($book->field_git_branch[LANGUAGE_NONE][0]['value'])) {
+      // get the branch
+      $branch = $book->field_git_branch[LANGUAGE_NONE][0]['value'];
+      // load the repo from the book
+      $repo = _git_book_get_repo($book);
+      // attempt to pull
+      $pull = _git_book_pull($repo, 'origin', $branch);
+      // update the nodes
+      git_book_gb_git_book_parse($path, $book);
+    }
+    else {
+      drush_print(dt('You must specify a branch in your git_book.'));
+    }
   }
   else {
     drush_print(dt('Book not found.'));

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
@@ -98,6 +98,11 @@ function drush_git_book_sync($name) {
  */
 function drush_git_book_status($name) {
   $book = _git_book_drush_get_book_by_name($name);
+  if ($book) {
+    $repo = _git_book_get_repo($book);
+    $status = _git_book_get_status($repo);
+    drush_print($status);
+  }
 }
 
 /**

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
@@ -31,6 +31,13 @@ function git_book_drush_command() {
     'arguments' => array(
       'name' => 'unique name of the gitbook.'
     ),
+  );
+  $commands['git-book-status'] = array(
+    'callback' => 'drush_git_book_status',
+    'description' => dt('Get the current status of a gitbook.'),
+    'arguments' => array(
+      'name' => 'unique name of the gitbook.'
+    ),
   ); 
 
   return $commands;
@@ -75,30 +82,46 @@ function drush_git_book_create($repo_url, $parser, $branch) {
  * Callback for command git-book-sync
  */
 function drush_git_book_sync($name) {
-  $selected_node = NULL;
-  $books = _git_book_get_books_by_name($name);
-  if ($books && !empty($books)) {
-    if (count($books) == 1) {
-      $selected_node = array_pop($books);
-    }
-    // if there is more than one node then we need to propmpt the user
-    // to choose.
-    else {
-      foreach ($nodes as $node) {
-        $drush_options[$node->nid] = $node->nid;
-      }
-      if (count($drush_options) > 1) {
-        $nid = drush_choice($drush_options, dt('Multple books with that name found. Which git book node would you like to update?'), '!value');
-        $selected_node = $nodes[$nid];
-      }
-    }
-  }
   // if we had a new selected node 
-  if ($selected_node) {
-    $path = _git_book_get_path($selected_node);
-    git_book_gb_git_book_parse($path, $selected_node);
+  $book = _git_book_drush_get_book_by_name($name);
+  if ($book) {
+    $path = _git_book_get_path($book);
+    git_book_gb_git_book_parse($path, $book);
   }
   else {
     drush_print(dt('Book not found.'));
   }
+}
+
+/**
+ * Callback for command git-book-status
+ */
+function drush_git_book_status($name) {
+  $books = _git_book_get_books_by_name($name);
+}
+
+/**
+ * Helper function to retrieve a single book by name
+ * @return  mixed    Returns book object or false if no book was found.
+ */
+function _git_book_drush_get_book_by_name($name) {
+  $books = _git_book_get_books_by_name($name);
+  if ($books && !empty($books)) {
+    if (count($books) == 1) {
+      // if there is only one then pop the book off of the array and return it
+      return array_pop($books);
+    }
+    // if there is more than one node then we need to propmpt the user
+    // to choose.
+    else {
+      foreach ($books as $node) {
+        $drush_options[$node->nid] = $node->nid;
+      }
+      if (count($drush_options) > 1) {
+        $nid = drush_choice($drush_options, dt('Multple books with that name found. Which git book node would you like to update?'), '!value');
+        return $books[$nid];
+      }
+    }
+  }
+  return false;
 }

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.drush.inc
@@ -24,6 +24,14 @@ function git_book_drush_command() {
       'branch' => 'branch to checkout'
     ),
   );
+  $commands['git-book-sync'] = array(
+    'callback' => 'drush_git_book_sync',
+    'aliases' => array('gcs'),
+    'description' => dt('Sync existing git book'),
+    'arguments' => array(
+      'node_id' => 'git_book node id'
+    ),
+  ); 
 
   return $commands;
 }
@@ -51,4 +59,17 @@ function drush_git_book_create($repo_url, $parser, $branch) {
   // save which will kick off processing of the node
   node_save($node);
   drush_print(dt('git book @repo_url successfully imported as @title', array('@repo_url' => $repo_url, '@title' => $title)));
+}
+
+/**
+ * Callback for command git-book-sync
+ */
+function drush_git_book_sync($nid) {
+  $node = node_load($nid);
+  // make sure it\s a gitbook node
+  if (isset($node->type) && $node->type == 'git_book') {
+    // get the gitbook outline
+    $path = _git_book_get_path($node);
+    git_book_gb_git_book_parse($path, $node);
+  }
 }

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -18,6 +18,50 @@ function git_book_node_presave($node) {
   }
 }
 
+function git_book_node_view($node, $viewmode) {
+  $status = _git_book_get_status($node);
+  dpm($status);
+  // $status = 'status is';
+  // $commit = 'commit #';
+  // $node->content['gitbook_status'] = array(
+  //   '#type' => 'markup',
+  //   '#markup' => $status,
+  // );
+} 
+
+/*
+ * Get the status of the git_book repo
+ */
+function _git_book_get_status($node) {
+  if ($node->type == 'git_book') {
+    $repo_url = $node->field_git_repo[LANGUAGE_NONE][0]['value'];
+    $repo = _git_book_get_repo($node->title, $repo_url);
+    dpm($repo);
+  }
+}
+
+/**
+ * Helper function to get a loaded repo object from url
+ */
+function _git_book_get_repo($name, $url) {
+  // build a path for this since its brand new and not hooked
+  // up to anything currently
+  $path = drupal_realpath('private://') . '/' . preg_replace('/[^a-z0-9]/', '', drupal_strtolower($name));
+  if (is_dir($path)) {
+    try {
+      libraries_load('gitphp');
+      $repo = Git::open($path);
+      if ($repo) {
+        return $repo;
+      }
+    }
+    catch (Exception $e) {
+      return false;
+    }
+  }
+  return false;
+}
+
 /**
  * Implements hook_node_insert().
  */

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -56,6 +56,7 @@ function git_book_node_insert($node) {
       $repo = Git::create($path);
       // tell the repo to NOT track permission changes
       $repo->run('config core.fileMode false');
+      $repo->run('config core.autocrlf false');
       $branch = 'master';
       if (isset($book->field_git_branch[LANGUAGE_NONE][0]['value'])) {
         $branch = $book->field_git_branch[LANGUAGE_NONE][0]['value'];

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -348,3 +348,21 @@ function _git_book_get_status($repo) {
   }
   return $status;
 }
+
+/**
+ * Helper function to retreave a list of git books by machine name
+ */
+function _git_book_get_books_by_name($name) {
+  $books = array();
+  $query = new EntityFieldQuery();
+  $entities = $query->entityCondition('entity_type', 'node')
+    ->propertyCondition('type', 'git_book')
+    ->propertyCondition('title', $name)
+    ->execute();
+  if (!empty($entities['node'])) {
+    $nodes = entity_load('node', array_keys($entities['node']));
+    $books = $nodes;
+  }
+
+  return $books;
+}

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -281,7 +281,9 @@ function _git_book_make_node($title, $content, $parent, $weight, $path = '') {
   if($node = node_submit($node)) {
     node_save($node);
   }
-  drush_print(t('@mode @title', array('@mode' => $mode,'@title' => $title)));
+  if (function_exists('drush_print')) {
+    drush_print(t('@mode @title', array('@mode' => $mode,'@title' => $title)));
+  }
   return $node;
 }
 

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -54,9 +54,11 @@ function git_book_node_insert($node) {
       // up to anything currently
       $path = drupal_realpath('private://') . '/' . preg_replace('/[^a-z0-9]/', '', drupal_strtolower($node->title));
       $repo = Git::create($path);
+      // tell the repo to NOT track permission changes
+      $repo->run('config core.fileMode false');
       $branch = 'master';
-      if (isset($node->field_git_branch[LANGUAGE_NONE][0]['value'])) {
-        $branch = $node->field_git_branch[LANGUAGE_NONE][0]['value'];
+      if (isset($book->field_git_branch[LANGUAGE_NONE][0]['value'])) {
+        $branch = $book->field_git_branch[LANGUAGE_NONE][0]['value'];
       }
       $repo->checkout($branch);
       $parsers = git_book_get_parsers();
@@ -76,8 +78,8 @@ function git_book_node_insert($node) {
         $repo = Git::create($path, $repo_url, true);
       }
       $branch = 'master';
-      if (isset($node->field_git_branch[LANGUAGE_NONE][0]['value'])) {
-        $branch = $node->field_git_branch[LANGUAGE_NONE][0]['value'];
+      if (isset($book->field_git_branch[LANGUAGE_NONE][0]['value'])) {
+        $branch = $book->field_git_branch[LANGUAGE_NONE][0]['value'];
       }
       $repo->checkout($branch);
       $parsers = git_book_get_parsers();
@@ -334,6 +336,14 @@ function _git_book_delete_folder($dirPath) {
  */
 function _git_book_get_path($node) {
   return drupal_realpath('private://') . '/' . preg_replace('/[^a-z0-9]/', '', drupal_strtolower($node->title));
+}
+
+/**
+ * Helper function to get current status of local repo object
+ */
+function _git_book_pull($repo, $remote, $branch) {
+  $status = _git_book_get_status($repo);
+  return $repo->pull($remote, $branch);
 }
 
 /**

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -242,7 +242,11 @@ function _git_book_make_node($title, $content, $parent, $weight, $path = '') {
   // if a node already exists at that url, then we are going to load it
   // and do an update of that node
   if ($url && $url !== $path) {
-    $node = menu_get_object('node', 1, $url);
+    // speparate the internal path into an array
+    $url_ary = explode('/', $url);
+    // load the node
+    $node = node_load($url_ary[1]);
+    // set the mode to updating instead of creating
     $mode = 'updating';
   }
   // if there was no existing node then we will create it

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -58,8 +58,8 @@ function git_book_node_insert($node) {
       $repo->run('config core.fileMode false');
       $repo->run('config core.autocrlf false');
       $branch = 'master';
-      if (isset($book->field_git_branch[LANGUAGE_NONE][0]['value'])) {
-        $branch = $book->field_git_branch[LANGUAGE_NONE][0]['value'];
+      if (isset($node->field_git_branch[LANGUAGE_NONE][0]['value'])) {
+        $branch = $node->field_git_branch[LANGUAGE_NONE][0]['value'];
       }
       $repo->checkout($branch);
       $parsers = git_book_get_parsers();
@@ -77,10 +77,13 @@ function git_book_node_insert($node) {
       }
       else {
         $repo = Git::create($path, $repo_url, true);
+        // tell the repo to NOT track permission changes
+        $repo->run('config core.fileMode false');
+        $repo->run('config core.autocrlf false');
       }
       $branch = 'master';
-      if (isset($book->field_git_branch[LANGUAGE_NONE][0]['value'])) {
-        $branch = $book->field_git_branch[LANGUAGE_NONE][0]['value'];
+      if (isset($node->field_git_branch[LANGUAGE_NONE][0]['value'])) {
+        $branch = $node->field_git_branch[LANGUAGE_NONE][0]['value'];
       }
       $repo->checkout($branch);
       $parsers = git_book_get_parsers();

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -18,35 +18,13 @@ function git_book_node_presave($node) {
   }
 }
 
-function git_book_node_view($node, $viewmode) {
-  $status = _git_book_get_status($node);
-  dpm($status);
-  // $status = 'status is';
-  // $commit = 'commit #';
-  // $node->content['gitbook_status'] = array(
-  //   '#type' => 'markup',
-  //   '#markup' => $status,
-  // );
-} 
-
-/*
- * Get the status of the git_book repo
- */
-function _git_book_get_status($node) {
-  if ($node->type == 'git_book') {
-    $repo_url = $node->field_git_repo[LANGUAGE_NONE][0]['value'];
-    $repo = _git_book_get_repo($node->title, $repo_url);
-    dpm($repo);
-  }
-}
-
 /**
  * Helper function to get a loaded repo object from url
  */
 function _git_book_get_repo($name, $url) {
   // build a path for this since its brand new and not hooked
   // up to anything currently
-  $path = drupal_realpath('private://') . '/' . preg_replace('/[^a-z0-9]/', '', drupal_strtolower($name));
+  $path = _git_book_get_path($name);
   if (is_dir($path)) {
     try {
       libraries_load('gitphp');

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -19,12 +19,12 @@ function git_book_node_presave($node) {
 }
 
 /**
- * Helper function to get a loaded repo object from url
+ * Helper function to get a loaded repo object from node object
  */
-function _git_book_get_repo($name, $url) {
+function _git_book_get_repo($node) {
   // build a path for this since its brand new and not hooked
   // up to anything currently
-  $path = _git_book_get_path($name);
+  $path = _git_book_get_path($node);
   if (is_dir($path)) {
     try {
       libraries_load('gitphp');
@@ -330,4 +330,17 @@ function _git_book_delete_folder($dirPath) {
  */
 function _git_book_get_path($node) {
   return drupal_realpath('private://') . '/' . preg_replace('/[^a-z0-9]/', '', drupal_strtolower($node->title));
+}
+
+/**
+ * Helper function to get current status of local repo object
+ */
+function _git_book_get_status($repo) {
+  $status = 'up-to-date';
+  $raw_status = $repo->run('status -sb');
+  preg_match('/\[(.*)\]/', $raw_status, $matches);
+  if (isset($matches[1])) {
+    $status = $matches[1];
+  }
+  return $status;
 }

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -259,23 +259,34 @@ function git_book_get_parsers() {
  * title and content.
  */
 function _git_book_make_node($title, $content, $parent, $weight, $path = '') {
-  $node = new stdClass();
-  $node->type = variable_get('book_child_type', 'book');
-  node_object_prepare($node);
-  $node->language = LANGUAGE_NONE;
-  if (!empty($path)) {
-    $node->path = array('alias' => $path);
+  $url = drupal_get_normal_path($path);
+  $mode = 'creating';
+  // if a node already exists at that url, then we are going to load it
+  // and do an update of that node
+  if ($url && $url !== $path) {
+    $node = menu_get_object('node', 1, $url);
+    $mode = 'updating';
   }
-  $node->status = 1;
-  $node->promote = 0;
-  $node->revision = 1;
-  // account for drush executing this and ensure it's owned by admin
-  // as drush operates as anon account in uid checks
-  if (drupal_is_cli()) {
-    $node->uid = 1;
-  }
+  // if there was no existing node then we will create it
   else {
-    $node->uid = $GLOBALS['user']->uid;
+    $node = new stdClass();
+    $node->type = variable_get('book_child_type', 'book');
+    node_object_prepare($node);
+    $node->language = LANGUAGE_NONE;
+    if (!empty($path)) {
+      $node->path = array('alias' => $path);
+    }
+    $node->status = 1;
+    $node->promote = 0;
+    $node->revision = 1;
+    // account for drush executing this and ensure it's owned by admin
+    // as drush operates as anon account in uid checks
+    if (drupal_is_cli()) {
+      $node->uid = 1;
+    }
+    else {
+      $node->uid = $GLOBALS['user']->uid;
+    }
   }
   // set values we pull in for the outline
   $node->title = $title;
@@ -292,10 +303,9 @@ function _git_book_make_node($title, $content, $parent, $weight, $path = '') {
   if($node = node_submit($node)) {
     node_save($node);
   }
+  drush_print(t('@mode @title', array('@mode' => $mode,'@title' => $title)));
   return $node;
 }
-
-
 
 /**
  * Build the book outline as a nested array
@@ -333,4 +343,11 @@ function _git_book_delete_folder($dirPath) {
           $path->isDir() && !$path->isLink() ? rmdir($path->getPathname()) : unlink($path->getPathname());
   }
   rmdir($dirPath);
+}
+
+/**
+ * Helper function to get the path of the repo from the node object
+ */
+function _git_book_get_path($node) {
+  return drupal_realpath('private://') . '/' . preg_replace('/[^a-z0-9]/', '', drupal_strtolower($node->title));
 }

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -341,6 +341,7 @@ function _git_book_get_path($node) {
  */
 function _git_book_get_status($repo) {
   $status = 'up-to-date';
+  $raw_status = $repo->run('fetch --all');
   $raw_status = $repo->run('status -sb');
   preg_match('/\[(.*)\]/', $raw_status, $matches);
   if (isset($matches[1])) {

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/git_book.module
@@ -346,7 +346,6 @@ function _git_book_get_path($node) {
  * Helper function to get current status of local repo object
  */
 function _git_book_pull($repo, $remote, $branch) {
-  $status = _git_book_get_status($repo);
   return $repo->pull($remote, $branch);
 }
 

--- a/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/modules/git_book_gb/git_book_gb.module
+++ b/core/dslmcode/stacks/courses/sites/all/modules/local_contrib/git_book/modules/git_book_gb/git_book_gb.module
@@ -113,7 +113,6 @@ function git_book_gb_git_book_parse($path, $node) {
  * @param  object  $parent   parent node
  */
 function _git_book_gb_parse(&$gb, $path, $parent, $weight = -15) {
-
   foreach ($gb as $nodes) {
     if (array_key_exists('title', $nodes) && array_key_exists('link', $nodes)) {
       $body = '';


### PR DESCRIPTION
Fixes #2088

Added a gitbook sync feature.  You can run `git-book-sync [name_of_book]` and it will pull changes from origin and run the parser to either create or updated content in the drupal book.

I also added to git config changes when creating the repo to minimize erroneous merge conflicts:
```
$repo->run('config core.fileMode false');
$repo->run('config core.autocrlf false');
```

There is one outstanding issue that I'm not sure how to solve, #2088.  However, if you manually clean up permissions with `leafy` after running the drush commands it works fine.

