### PR TITLE
Render web components in H5P text fields

### DIFF
--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_h5p/elmslnmedia_h5p.api.php
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_h5p/elmslnmedia_h5p.api.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @file
+ * Example hooks for the ELMSMedia H5P feature.
+ */
+
+/**
+ * Alter the list of allowed tags to put outputed in the h5p questions.
+ */
+function hook_elmsln_h5p_allowed_tags_alter(&$allowed_tags) {
+  $allowed_tags[] = 'em';
+  $allowed_tags[] = 'video';
+  $allowed_tags[] = 'my-custom-tag';
+}

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_h5p/elmsmedia_h5p.install
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_h5p/elmsmedia_h5p.install
@@ -7,3 +7,10 @@ function elmsmedia_h5p_update_7000() {
     variable_set('h5p_hub_is_enabled', FALSE);
     variable_set('h5p_send_usage_statistics', FALSE);
 }
+
+/*
+ * Instantiate elmsln_h5p_allowed_tags variable
+ */
+function elmsmedia_h5p_update_7001() {
+    variable_set('elmsln_h5p_allowed_tags', array());
+}

--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_h5p/elmsmedia_h5p.module
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_h5p/elmsmedia_h5p.module
@@ -58,3 +58,51 @@ function elmsmedia_h5p_replicate_ui_access_check_alter(&$access, $type, $entity)
     $access = FALSE;
   }
 }
+
+/**
+ * Impliments hook_h5p_filtered_params_alter
+ *
+ * Replace H5P's text filter with Drupal's xss filter.
+ */
+function elmsmedia_h5p_h5p_filtered_params_alter(&$filtered) {
+  // Get the list of allowed tags
+  $allowed_tags = variable_get('elmsmedia_h5p_allowed_tags', array());
+  $allowed_tags = _elmsmedia_variable_formatter($allowed_tags);
+  drupal_alter('elmsln_h5p_allowed_tags', $allowed_tags);
+  // find questions and answers
+  foreach ($filtered->choices as &$choice) {
+    // decode H5P's escaping
+    $choice->question = html_entity_decode($choice->question);
+    // run it through drupal's xss filter but whitelist our allowed tags
+    $choice->question = filter_xss($choice->question, $allowed_tags);
+    if (isset($choice->answers)) {
+      foreach ($choice->answers as &$answer) {
+        // decode H5P's escaping
+        $answer = html_entity_decode($answer);
+        // run it through drupal's xss filter but whitelist our allowed tags
+        $answer = filter_xss($answer, $allowed_tags);
+      }
+    }
+  }
+}
+
+/**
+ * Helper function to format the form values to variable arrays
+ * @param  [mixed: string or array] Either array or comma separated string that will be converted an array.
+ * @return [array]
+ */
+function _elmsmedia_variable_formatter($variable) {
+  $array = array();
+  if (is_string($variable)) {
+    // trim the whitespace from the attributes
+    $variable = explode(',', $variable);
+    foreach ($variable as $key => $value) {
+      $array[$key] = trim($value);
+    }
+  }
+  elseif (is_array($variable)) {
+    $array = $variable;
+  }
+
+  return $array;
+}


### PR DESCRIPTION
This allows you to add whitelisted tags that will be rendered in h5p text areas. You add tags via `elmsln_h5p_allowed_tags` variable or with `hook_elmsln_h5p_allowed_tags_alter`.

This has only been tested with H5P Single Choice Option.

Fixes #2087
