### PR TITLE
Bullet and Number Lists Styling

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/css/main.css
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/css/main.css
@@ -2942,10 +2942,10 @@ code {
 ul,
 ol,
 dl {
-  font-size: 1rem;
-  line-height: 1.6;
+  font-size: 1.2rem;
+  line-height: 2.5rem;
   list-style-position: outside;
-  margin-bottom: 1.25rem; }
+  margin-bottom: 1.5rem; }
 
 ul {
   margin-left: 1.1rem; }


### PR DESCRIPTION
Updates line 2945 of main.css for ul, ol, dl font-size and line-height to match p.

<img width="839" alt="2144" src="https://user-images.githubusercontent.com/22225779/29427509-0596f946-8358-11e7-9842-8b57501ff3e0.png">


Fixes #2144 
