### PR TITLE
Studio

### DIFF
--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/lrnapp-studio-kanban/lrnapp-studio-kanban.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/lrnapp-studio-kanban/lrnapp-studio-kanban.php
@@ -60,9 +60,12 @@ function _cle_studio_kanban_kanban_data($machine_name, $app_route, $params, $arg
         $project->relationships->assignments = array();
         // loop through the steps and pull in all the assignments
         foreach ($project->attributes->steps as $step) {
-          $assignment = $assignmentservice->getAssignment($step->id, $app_route);
-          if (isset($assignment->id)) {
-            $project->relationships->assignments['assignment-' . $assignment->id] = $assignment;
+          $assignment = $assignmentservice->getAssignment($step->id);
+          if ($assignment) {
+            $encoded_assignment = $assignmentservice->encodeAssignment($assignment, $app_route);
+            if ($encoded_assignment) {
+              $project->relationships->assignments['assignment-' . $encoded_assignment->id] = $encoded_assignment;
+            }
           }
         }
       }

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/lrnapp-studio-kanban/lrnapp-studio-kanban.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/lrnapp-studio-kanban/lrnapp-studio-kanban.php
@@ -272,6 +272,11 @@ function _cle_studio_kanban_assignment_index($machine_name, $app_route, $params,
   $service = new CleOpenStudioAppAssignmentService();
 
   $return = $service->getAssignments();
+  $items = $this->encodeAssignments($items, $app_route);
+  foreach ($items as $key => $data) {
+    $return['assignment-' . $key] = $data;
+  }
+  return $return;
 
   return array(
     'status' => 200,

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/lrnapp-studio-kanban/lrnapp-studio-kanban.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/lrnapp-studio-kanban/lrnapp-studio-kanban.php
@@ -239,9 +239,9 @@ function _cle_studio_kanban_assignment_create_stub($machine_name, $app_route, $p
       $service = new CleOpenStudioAppAssignmentService();
       try {
         $assignment = $service->createStubAssignment($post_data);
-        if ($assignment) {
+        if (isset($assignment->nid)) {
           $return['status'] = 201;
-          $return['data'] = $assignment;
+          $return['data'] = $service->encodeAssignment($assignment, $app_route);
         }
         else {
           $return['errors'][] = t('Could not create assignment.');

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/lrnapp-studio-kanban/src/lrnapp-studio-kanban/lrnapp-studio-assignment-display.html
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/lrnapp-studio-kanban/src/lrnapp-studio-kanban/lrnapp-studio-assignment-display.html
@@ -1,0 +1,27 @@
+
+<dom-module id="lrnapp-studio-assignment-display">
+  <template>
+    <style>
+      :host {
+        display: block;
+        padding: 1em;
+      }
+
+      #assignment-body {
+        font-size: 1.3em;
+      }
+    </style>
+    <h1>[[assignment.attributes.title]]</h1>
+    <marked-element id="assignment-body" markdown="[[assignment.attributes.body]]"></marked-element>
+  </template>
+  <script>
+    Polymer({
+      is: 'lrnapp-studio-assignment-display',
+      properties: {
+        assignment: {
+          type: Object
+        }
+      }
+    });
+  </script>
+</dom-module>

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppAssignmentService.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppAssignmentService.php
@@ -16,13 +16,14 @@ class CleOpenStudioAppAssignmentService {
     $node->uid = $user->uid;
     $node->status = 1;
     $node->field_assignment_project['und'][0]['target_id'] = $project_id;
+    $node->field_critique_method[LANGUAGE_NONE][0]['value'] = 'none';
     // associate to the currently active section
     $node->og_group_ref[LANGUAGE_NONE][0]['target_id'] = _cis_section_load_section_by_id(_cis_connector_section_context());
     if (entity_access('create', 'node', $node)) {
       try {
         node_save($node);
         if (isset($node->nid)) {
-          return $this->encodeAssignment($node);
+          return $node;
         }
       }
       catch (Exception $e) {
@@ -216,7 +217,7 @@ class CleOpenStudioAppAssignmentService {
    *
    * @return array
    */
-  protected function encodeAssignments($assignments, $app_route) {
+  public function encodeAssignments($assignments, $app_route) {
     if (is_array($assignments)) {
       foreach ($assignments as &$assignment) {
         $assignment = $this->encodeAssignment($assignment, $app_route);
@@ -236,7 +237,7 @@ class CleOpenStudioAppAssignmentService {
    *
    * @return Object
    */
-  protected function encodeAssignment($assignment, $app_route = '') {
+  public function encodeAssignment($assignment, $app_route = '') {
     global $user;
     global $base_url;
     $account = $user;
@@ -391,7 +392,7 @@ class CleOpenStudioAppAssignmentService {
     return NULL;
   }
 
-  protected function decodeAssignment($payload, $node) {
+  public function decodeAssignment($payload, $node) {
     if ($payload) {
       if ($payload->attributes) {
         if ($payload->attributes->title) {
@@ -407,7 +408,7 @@ class CleOpenStudioAppAssignmentService {
   }
 
   // Convert multidimentional Object to arrays
-  private function objectToArray($obj) {
+  public function objectToArray($obj) {
     if (is_object($obj)) $obj = (array)$obj;
     if (is_array($obj)) {
         $new = array();
@@ -420,7 +421,7 @@ class CleOpenStudioAppAssignmentService {
     return $new;
   }
 
-  private function fileFieldTypes($entity_type, $field_name, $bundle_name) {
+  public function fileFieldTypes($entity_type, $field_name, $bundle_name) {
     $instance = field_info_instance($entity_type, $field_name, $bundle_name);
     if ($instance && is_array($instance)) {
       if (isset($instance['settings'])) {

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppAssignmentService.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppAssignmentService.php
@@ -66,11 +66,7 @@ class CleOpenStudioAppAssignmentService {
       }
     }
     $items = _cis_connector_assemble_entity_list('node', 'cle_assignment', 'nid', '_entity', $field_conditions, $property_conditions, $orderby, TRUE, $limit);
-    $items = $this->encodeAssignments($items);
-    foreach ($items as $key => $data) {
-      $return['assignment-' . $key] = $data;
-    }
-    return $return;
+    return $items;
   }
 
   /**
@@ -220,10 +216,10 @@ class CleOpenStudioAppAssignmentService {
    *
    * @return array
    */
-  protected function encodeAssignments($assignments) {
+  protected function encodeAssignments($assignments, $app_route) {
     if (is_array($assignments)) {
       foreach ($assignments as &$assignment) {
-        $assignment = $this->encodeAssignment($assignment);
+        $assignment = $this->encodeAssignment($assignment, $app_route);
       }
       return $assignments;
     }

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppAssignmentService.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppAssignmentService.php
@@ -74,11 +74,14 @@ class CleOpenStudioAppAssignmentService {
    *
    * @param string $id
    *    Nid of the assignment
+   * @param array $options
+   *    - encode Boolean Specify whether the assignment should be encoded
    *
    * @return object
    */
-  public function getAssignment($id, $app_route = '') {
+  public function getAssignment($id, $options = array()) {
     $item = array();
+    $encode = (isset($options['encode']) ? $options['encode'] : TRUE);
     $section_id = _cis_connector_section_context();
     $section = _cis_section_load_section_by_id($section_id);
     $field_conditions = array(
@@ -95,7 +98,10 @@ class CleOpenStudioAppAssignmentService {
      *       one was found.
      */
     if (count($items) == 1) {
-      $item = $this->encodeAssignment(array_shift($items), $app_route);
+      $item = array_shift($items);
+      if ($encode) {
+        $item = $this->encodeAssignment(array_shift($items));
+      }
     }
     return $item;
   }
@@ -148,6 +154,13 @@ class CleOpenStudioAppAssignmentService {
 
   public function videoGenerateSourceUrl($url) {
     return _elmsln_api_video_url($url);
+  }
+
+  public function openDependencies($assignment_id) {
+    ddl('test');
+    $assignment = $this->getAssignment($assignment_id, array('encode' => FALSE));
+    ddl($assignment);
+    return FALSE;
   }
 
   /**

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppAssignmentService.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppAssignmentService.php
@@ -75,12 +75,10 @@ class CleOpenStudioAppAssignmentService {
    *
    * @param string $id
    *    Nid of the assignment
-   * @param array $options
-   *    - encode Boolean Specify whether the assignment should be encoded
    *
    * @return object
    */
-  public function getAssignment($id, $options = array()) {
+  public function getAssignment($id) {
     $item = array();
     $encode = (isset($options['encode']) ? $options['encode'] : TRUE);
     $section_id = _cis_connector_section_context();
@@ -102,9 +100,6 @@ class CleOpenStudioAppAssignmentService {
      */
     if (count($items) == 1) {
       $item = array_shift($items);
-      if ($encode) {
-        $item = $this->encodeAssignment($item);
-      }
     }
     return $item;
   }
@@ -181,11 +176,11 @@ class CleOpenStudioAppAssignmentService {
    * @return object/false
    */
   public function getAssignmentDependency($assignment_id) {
-    $assignment = $this->getAssignment($assignment_id, array('encode' => FALSE));
+    $assignment = $this->getAssignment($assignment_id);
     if ($assignment) {
       // if we have a dependency
       if (isset($assignment->field_assignment_dependencies[LANGUAGE_NONE][0]['target_id'])) {
-        return $this->getAssignment($assignment->field_assignment_dependencies[LANGUAGE_NONE][0]['target_id'], array('encode' => FALSE));
+        return $this->getAssignment($assignment->field_assignment_dependencies[LANGUAGE_NONE][0]['target_id']);
       }
     }
     return FALSE;

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppSubmissionService.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppSubmissionService.php
@@ -177,7 +177,7 @@ class CleOpenStudioAppSubmissionService {
    */
   public function getSubmissionByAssignment($assignment_id) {
     global $user;
-    $item = array();
+    $return = FALSE;
     $section_id = _cis_connector_section_context();
     $section = _cis_section_load_section_by_id($section_id);
     $field_conditions = array(
@@ -187,7 +187,7 @@ class CleOpenStudioAppSubmissionService {
     $query->entityCondition('entity_type', 'node')
       ->entityCondition('bundle', 'cle_submission')
       ->propertyCondition('status', NODE_PUBLISHED)
-      ->propertyCondition('uid', $user->uid, '=')
+      ->propertyCondition('uid', $user->uid)
       ->fieldCondition('field_assignment', 'target_id', $assignment_id, '=');
     $result = $query->execute();
     if (isset($result['node'])) {
@@ -196,23 +196,9 @@ class CleOpenStudioAppSubmissionService {
        *       one was found.
        */
       $nids = array_keys($result['node']);
-      $item = node_load(array_shift($nids));
+      $return = node_load(array_shift($nids));
     }
-    return $item;
-  }
-
-  /**
-   * Find out if the parent assignment of a submission is complete
-   *
-   * @param [string] $assignment_id
-   * @return boolean
-   */
-  public function assignmentComplete($assignment_id) {
-    $submission = $this->getSubmissionByAssignment($assignment_id);
-    if ($submission->field_submission_state[LANGUAGE_NONE][0]['value'] == 'submission_ready') {
-      return TRUE;
-    }
-    return FALSE;
+    return $return;
   }
 
   /**

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppSubmissionService.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppSubmissionService.php
@@ -38,7 +38,7 @@ class CleOpenStudioAppSubmissionService {
    * This will take into concideration what section the user is in and what section
    * they have access to.
    */
-  public function getSubmissions($options) {
+  public function getSubmissions($options = NULL) {
     $items = array();
     $section_id = _cis_connector_section_context();
     $section = _cis_section_load_section_by_id($section_id);
@@ -85,11 +85,14 @@ class CleOpenStudioAppSubmissionService {
    *
    * @param string $id
    *    Nid of the submission
+   * @param array $options
+   *    - encode [boolean] Specify whether the submission should be encoded.
    *
    * @return object
    */
-  public function getSubmission($id) {
+  public function getSubmission($id, $options = array()) {
     $item = array();
+    $encode = (isset($options['encode']) ? $options['encode'] : TRUE);
     $section_id = _cis_connector_section_context();
     $section = _cis_section_load_section_by_id($section_id);
     $field_conditions = array(
@@ -106,7 +109,10 @@ class CleOpenStudioAppSubmissionService {
      *       one was found.
      */
     if (count($items) == 1) {
-      $item = $this->encodeSubmission(array_shift($items));
+      $item = array_shift($items);
+      if ($encode) {
+        $item = $this->encodeSubmission($item);
+      }
     }
     return $item;
   }
@@ -161,6 +167,52 @@ class CleOpenStudioAppSubmissionService {
 
   public function videoGenerateSourceUrl($url) {
     return _elmsln_api_video_url($url);
+  }
+
+  /**
+   * Get a submission for a paticular user by submission id
+   *
+   * @param [string] $id  Assignment id
+   * @return [node_object] Submission node object
+   */
+  public function getSubmissionByAssignment($assignment_id) {
+    global $user;
+    $item = array();
+    $section_id = _cis_connector_section_context();
+    $section = _cis_section_load_section_by_id($section_id);
+    $field_conditions = array(
+      'og_group_ref' => array('target_id', $section, '='),
+    );
+    $query = new EntityFieldQuery();
+    $query->entityCondition('entity_type', 'node')
+      ->entityCondition('bundle', 'cle_submission')
+      ->propertyCondition('status', NODE_PUBLISHED)
+      ->propertyCondition('uid', $user->uid, '=')
+      ->fieldCondition('field_assignment', 'target_id', $assignment_id, '=');
+    $result = $query->execute();
+    if (isset($result['node'])) {
+      /**
+       * @todo add better checks to return status codes based on if none were found or if more than
+       *       one was found.
+       */
+      $nids = array_keys($result['node']);
+      $item = node_load(array_shift($nids));
+    }
+    return $item;
+  }
+
+  /**
+   * Find out if the parent assignment of a submission is complete
+   *
+   * @param [string] $assignment_id
+   * @return boolean
+   */
+  public function assignmentComplete($assignment_id) {
+    $submission = $this->getSubmissionByAssignment($assignment_id);
+    if ($submission->field_submission_state[LANGUAGE_NONE][0]['value'] == 'submission_ready') {
+      return TRUE;
+    }
+    return FALSE;
   }
 
   /**

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppSubmissionService.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/apps/services/CleOpenStudioAppSubmissionService.php
@@ -246,9 +246,6 @@ class CleOpenStudioAppSubmissionService {
     // if it's potentially visible to the class then make sure this user can see it
     if ($visible_to_class) {
       // check if the submission is set to be open after submission
-      /**
-       * @todo this line is throwing a 500 error when viewing a submission as a student
-       */
       $privacy_setting = $submission_emw->field_assignment->field_assignment_privacy_setting->value();
       if ($privacy_setting && $privacy_setting == 'open_after_submission') {
         // if it is, then we should check if the user has submitted to this assignment and the submission

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/tests/assignmentDependenciesComplete.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/tests/assignmentDependenciesComplete.php
@@ -1,0 +1,11 @@
+<?php
+
+include_once drupal_get_path('module', 'cle_open_studio_app') . '/apps/services/CleOpenStudioAppAssignmentService.php';
+
+$assignment_id = drush_shift();
+
+// Make sure that the submissions parent assignment has it's dependencies met.
+$assignment_service = new CleOpenStudioAppAssignmentService();
+$unmet = $assignment_service->assignmentHasUnmetDependencies($assignment_id);
+
+drush_print_r(($unmet ? 'unmet' : 'good to submit'));

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/tests/critiqueScenario.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/tests/critiqueScenario.php
@@ -1,0 +1,26 @@
+<?php
+
+include_once drupal_get_path('module', 'cle_open_studio_app') . '/apps/services/CleOpenStudioAppAssignmentService.php';
+include_once drupal_get_path('module', 'cle_open_studio_app') . '/apps/services/CleOpenStudioAppProjectService.php';
+include_once drupal_get_path('module', 'cle_open_studio_app') . '/apps/services/CleOpenStudioAppSubmissionService.php';
+
+$project_service = new CleOpenStudioAppProjectService();
+$assignment_service = new CleOpenStudioAppAssignmentService();
+$submission_service = new CleOpenStudioAppSubmissionService();
+
+// Delete Assignments
+$assignments = $assignment_service->getAssignments();
+foreach ($assignments as $assignment) {
+  node_delete($assignment->nid);
+}
+// Delete Submissions
+$submissions = $submission_service->getSubmissions();
+foreach ($submissions as $submission) {
+  node_delete($submission->nid);
+}
+
+// Project 1
+$project1 = $project_service->createStubProject();
+drush_print_r($project1);
+// Create Assignments
+// $assignment1 = $assignment_service->createStubAssignment();

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/tests/encodeAssignment.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/tests/encodeAssignment.php
@@ -1,0 +1,9 @@
+<?php
+
+include_once drupal_get_path('module', 'cle_open_studio_app') . '/apps/services/CleOpenStudioAppAssignmentService.php';
+
+$assignment_id = drush_shift();
+$assignment_service = new CleOpenStudioAppAssignmentService();
+$assignment = node_load($assignment_id);
+$encoded_assignment = $assignment_service->encodeAssignment($assignment);
+drush_print_r($encoded_assignment);

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/tests/submissionVisible.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/tests/submissionVisible.php
@@ -1,0 +1,23 @@
+<?php
+
+include_once drupal_get_path('module', 'cle_open_studio_app') . '/apps/services/CleOpenStudioAppSubmissionService.php';
+
+$submission_id = drush_shift();
+
+// Make sure that the submissions parent assignment has it's dependencies met.
+$submission_service = new CleOpenStudioAppSubmissionService();
+$visible_to_class = $submission_service->submissionVisibleToClass($submission_id);
+$message = ($visible_to_class ? 'visible to Class' : 'not visible to class');
+drush_print_r('Class Access: ' . $message);
+
+// Check submission visibility for user
+$visible = $submission_service->submissionVisibleToUser($submission_id);
+$message = ($visible ? 'visible' : 'not visible to class');
+drush_print_r('User Access: ' . $message);
+
+// Check the hook_node_access
+global $user;
+$submission_node = node_load($submission_id);
+$node_access = cle_submission_node_access($submission_node, 'view', $user);
+$message = ($node_access == NULL ? 'allowed' : $node_access);
+drush_print_r('Hook Node Access ' . $message);

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/tests/submissionVisible.php
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/apps/cle_open_studio_app/tests/submissionVisible.php
@@ -1,23 +1,33 @@
 <?php
 
+/**
+ * @file CLE Submission drush test script to check the visiblity
+ * of a submission for a user
+ *
+ * Example Usage:
+ * $ drush @studio.math033 scr submissionVisible.php [submission_nid] --user=[uid]
+ * $ drush @studio.math033 scr submissionVisible.php 89 --user=4
+ */
+
 include_once drupal_get_path('module', 'cle_open_studio_app') . '/apps/services/CleOpenStudioAppSubmissionService.php';
 
+// Get the submission id from the drush arguments
 $submission_id = drush_shift();
 
 // Make sure that the submissions parent assignment has it's dependencies met.
 $submission_service = new CleOpenStudioAppSubmissionService();
 $visible_to_class = $submission_service->submissionVisibleToClass($submission_id);
-$message = ($visible_to_class ? 'visible to Class' : 'not visible to class');
+$message = ($visible_to_class ? 'visible' : 'hidden');
 drush_print_r('Class Access: ' . $message);
 
 // Check submission visibility for user
 $visible = $submission_service->submissionVisibleToUser($submission_id);
-$message = ($visible ? 'visible' : 'not visible to class');
+$message = ($visible ? 'visible' : 'hidden');
 drush_print_r('User Access: ' . $message);
 
 // Check the hook_node_access
 global $user;
 $submission_node = node_load($submission_id);
-$node_access = cle_submission_node_access($submission_node, 'view', $user);
-$message = ($node_access == NULL ? 'allowed' : $node_access);
-drush_print_r('Hook Node Access ' . $message);
+$node_access = node_access('view', $submission_node, $user);
+$message = ($node_access ? 'visible' : 'hidden');
+drush_print_r('Hook Node Access: ' . $message);

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_assignment/cle_assignment.features.field_base.inc
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_assignment/cle_assignment.features.field_base.inc
@@ -85,7 +85,7 @@ function cle_assignment_field_default_field_bases() {
   // Exported field_base: 'field_assignment_dependencies'.
   $field_bases['field_assignment_dependencies'] = array(
     'active' => 1,
-    'cardinality' => -1,
+    'cardinality' => 1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_assignment_dependencies',

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_assignment/cle_assignment.module
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_assignment/cle_assignment.module
@@ -105,7 +105,6 @@ function cle_assignment_node_presave($node) {
         throw new Exception($message);
       }
     }
-
     // if we have a critique method chosen then we need to ensure we have a
     // parent submission
     if ($node->field_critique_method[LANGUAGE_NONE][0]['value'] != 'none') {

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_assignment/cle_assignment.module
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_assignment/cle_assignment.module
@@ -93,6 +93,32 @@ function cle_assignment_page_build(&$page) {
 }
 
 /**
+ * Implements hook_node_presave().
+ */
+function cle_assignment_node_presave($node) {
+  if ($node->type == 'cle_assignment') {
+    // make sure that an assignment doesn't list itself as a dependency.
+    if (isset($node->field_assignment_dependencies['und'][0]['target_id']) && isset($node->nid)) {
+      if ($node->field_assignment_dependencies['und'][0]['target_id'] == $node->nid) {
+        $message = t('An assignment can not list itself as a dependency.');
+        watchdog('cle_assignment_presave', $message, array('nid' => $node->nid), WATCHDOG_ERROR);
+        throw new Exception($message);
+      }
+    }
+
+    // if we have a critique method chosen then we need to ensure we have a
+    // parent submission
+    if ($node->field_critique_method[LANGUAGE_NONE][0]['value'] != 'none') {
+      if (!isset($node->field_assignment_dependencies['und'][0]['target_id']) || !$node->field_assignment_dependencies['und'][0]['target_id']) {
+        $message = t('An critique assignment must have an assignment dependency.');
+        watchdog('cle_assignment_presave', $message, array('nid' => $node->nid), WATCHDOG_ERROR);
+        throw new Exception($message);
+      }
+    }
+  }
+}
+
+/**
  * ELMSLN JSapi callback for creating an assignment.
  * @todo  make this use the full POST data sanitized and in params.
  */

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_submission/cle_submission.module
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_submission/cle_submission.module
@@ -382,16 +382,12 @@ function cle_submission_page_build(&$page) {
  * Implements hook_node_access().
  */
 function cle_submission_node_access($node, $op, $account) {
+  $submission_service = new CleOpenStudioAppSubmissionService();
   // allow for privacy value on the assignment to dictate who can see this
   if ($op == 'view' && !_cis_connector_role_groupings(array('teacher', 'staff', 'webservice'), $account) && $node->type == 'cle_submission' && $node->uid != $account->uid) {
-    // see if this assignment is private
-    $assignment = node_load($node->field_assignment['und'][0]['target_id']);
-    // boolean for visibility
-    if ($assignment->field_assignment_privacy_setting['und'][0]['value'] == 'closed') {
-      // if it's a hidden assignment, the last check is admin member
-      if (!_cle_submission_submission_being_critiqued($node, $account)) {
-        return NODE_ACCESS_DENY;
-      }
+    $visible = $submission_service->submissionVisibleToUser($node);
+    if (!$visible) {
+      return NODE_ACCESS_DENY;
     }
   }
   return NODE_ACCESS_IGNORE;
@@ -540,7 +536,7 @@ function _cle_submission_submission_being_critiqued($submission, $user = NULL) {
     $submission_nids = array_keys($result['node']);
     $submissions = entity_load('node', $submission_nids);
     return $submissions;
-  } 
+  }
 
   return false;
 }

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_submission/cle_submission.module
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_submission/cle_submission.module
@@ -6,6 +6,7 @@
 
 include_once 'cle_submission.features.inc';
 include_once drupal_get_path('module', 'cle_open_studio_app') . '/apps/services/CleOpenStudioAppSubmissionService.php';
+include_once drupal_get_path('module', 'cle_open_studio_app') . '/apps/services/CleOpenStudioAppAssignmentService.php';
 
 /**
  * Implements hook_menu().
@@ -409,11 +410,16 @@ function cle_submission_node_presave($node) {
     }
 
     // Make sure that the submissions parent assignment has it's dependencies met.
-    $submission_service = new CleOpenStudioAppSubmissionService();
-    $assignment = $node->field_assignment[LANGUAGE_NONE][0]['target_id'];
-    $res = $submission_service->assignmentComplete($assignment);
+    $assignment_service = new CleOpenStudioAppAssignmentService();
+    if (isset($node->field_assignment[LANGUAGE_NONE][0]['target_id'])) {
+      $assignment_id = $node->field_assignment[LANGUAGE_NONE][0]['target_id'];
+      $has_unmet_dependencies = $assignment_service->assignmentHasUnmetDependencies($assignment_id);
+      if ($has_unmet_dependencies) {
+        throw new Exception(t('You must complete the previous assignment before you can submit assignment.'));
+      }
+    }
 
-    // load the parent assignment
+    // figure out submission type
     $entity = entity_load_single('node', $node->field_assignment[LANGUAGE_NONE][0]['target_id']);
     $entity_efw = entity_metadata_wrapper('node', $entity);
     // Figure out critique method

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_submission/cle_submission.module
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_submission/cle_submission.module
@@ -5,6 +5,7 @@
  */
 
 include_once 'cle_submission.features.inc';
+include_once drupal_get_path('module', 'cle_open_studio_app') . '/apps/services/CleOpenStudioAppSubmissionService.php';
 
 /**
  * Implements hook_menu().
@@ -402,11 +403,21 @@ function cle_submission_node_access($node, $op, $account) {
 function cle_submission_node_presave($node) {
   // Check the parent assignment to find out what type of submission should be.
   if ($node->type == 'cle_submission') {
+    // ensure we have a parent assignment
+    if (!isset($node->field_assignment[LANGUAGE_NONE][0]['target_id'])) {
+      throw new Exception(t('Submissions need to have a parent assignment.'));
+    }
+
+    // Make sure that the submissions parent assignment has it's dependencies met.
+    $submission_service = new CleOpenStudioAppSubmissionService();
+    $assignment = $node->field_assignment[LANGUAGE_NONE][0]['target_id'];
+    $res = $submission_service->assignmentComplete($assignment);
+
+    // load the parent assignment
     $entity = entity_load_single('node', $node->field_assignment[LANGUAGE_NONE][0]['target_id']);
     $entity_efw = entity_metadata_wrapper('node', $entity);
+    // Figure out critique method
     $return = 'default';
-    $entity = entity_load_single('node', $node->field_assignment[LANGUAGE_NONE][0]['target_id']);
-    $entity_efw = entity_metadata_wrapper('node', $entity);
     if ($entity_efw) {
       $assignment_critique = $entity_efw->field_critique_method->value();
       if ($assignment_critique) {

--- a/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_submission/cle_submission.module
+++ b/core/dslmcode/profiles/cle-7.x-2.x/modules/features/cle_submission/cle_submission.module
@@ -400,13 +400,15 @@ function cle_submission_node_access($node, $op, $account) {
 function cle_submission_node_presave($node) {
   // Check the parent assignment to find out what type of submission should be.
   if ($node->type == 'cle_submission') {
+    $submission_service = new CleOpenStudioAppSubmissionService();
+    $assignment_service = new CleOpenStudioAppAssignmentService();
+
     // ensure we have a parent assignment
     if (!isset($node->field_assignment[LANGUAGE_NONE][0]['target_id'])) {
       throw new Exception(t('Submissions need to have a parent assignment.'));
     }
 
     // Make sure that the submissions parent assignment has it's dependencies met.
-    $assignment_service = new CleOpenStudioAppAssignmentService();
     if (isset($node->field_assignment[LANGUAGE_NONE][0]['target_id'])) {
       $assignment_id = $node->field_assignment[LANGUAGE_NONE][0]['target_id'];
       $has_unmet_dependencies = $assignment_service->assignmentHasUnmetDependencies($assignment_id);
@@ -416,12 +418,12 @@ function cle_submission_node_presave($node) {
     }
 
     // figure out submission type
-    $entity = entity_load_single('node', $node->field_assignment[LANGUAGE_NONE][0]['target_id']);
-    $entity_efw = entity_metadata_wrapper('node', $entity);
+    $assignment = entity_load_single('node', $node->field_assignment[LANGUAGE_NONE][0]['target_id']);
+    $assignment_emw = entity_metadata_wrapper('node', $assignment);
     // Figure out critique method
     $return = 'default';
-    if ($entity_efw) {
-      $assignment_critique = $entity_efw->field_critique_method->value();
+    if ($assignment_emw) {
+      $assignment_critique = $assignment_emw->field_critique_method->value();
       if ($assignment_critique) {
         if ($assignment_critique != 'none') {
           $return = 'critique';
@@ -434,16 +436,25 @@ function cle_submission_node_presave($node) {
     // If this submission needs to have a critique submission automatically assigned to it
     // then do it here.
     // $critique_cle_critique_random($node->field_assignment[LANGUAGE_NONE][0]['target_id']);
-    if ($entity_efw) {
-      $assignment_critique = $entity_efw->field_critique_method->value();
+    if ($assignment_emw) {
+      $assignment_critique = $assignment_emw->field_critique_method->value();
       if ($assignment_critique) {
         if ($assignment_critique == 'random') {
-          $critique_submission = _cle_critique_random($entity->nid);
-          if ($critique_submission) {
-            $node->field_related_submission[LANGUAGE_NONE][0]['target_id'] = $critique_submission->nid;
+          // get the assignments dependency
+          $assignment_dependency_nid = $assignment_emw->field_assignment_dependencies->nid->value();
+          if ($assignment_dependency_nid) {
+            // Attempt to find a critique
+            $critique_submission = $submission_service->getSubmissionToCritique($assignment_dependency_nid);
+            // if we found one then we will assign to this submissions related submission.
+            if ($critique_submission) {
+              $node->field_related_submission[LANGUAGE_NONE][0]['target_id'] = $critique_submission->nid;
+            }
+            else {
+              throw new Exception(t('There are no submissions to critique at this time. Please check back later.'));
+            }
           }
           else {
-            throw new Exception(t('There are no submissions to critique at this time. Please check back later.'));
+            throw new Exception(t('This assignment does not have a dependency that is needed for critiquing.'));
           }
         }
       }

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/elmsln_student_filter/elmsln_student_filter.features.filter.inc
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/features/elmsln_student_filter/elmsln_student_filter.features.filter.inc
@@ -54,7 +54,7 @@ function elmsln_student_filter_filter_default_formats() {
         'weight' => -10,
         'status' => 1,
         'settings' => array(
-          'allowed_html' => '<a> <em> <strong> <h3> <iframe> <code> <ul> <ol> <li> <video> <source> <img>',
+          'allowed_html' => '<a> <em> <strong> <h3> <iframe> <code> <ul> <ol> <li> <video> <source> <img> <lrn-math>',
           'filter_html_help' => 1,
           'filter_html_nofollow' => 0,
         ),


### PR DESCRIPTION
- moved encoding out of getAssignment(s) calls
- made an `assisgnment-display` component
- added node_access checks for hiding and showing submissions based on assignment-privacy settings.
- added assignment presave conditions
  - if we have a critique method chosen then we need to ensure we have a parent submission
  - assignment can not list itself as a dependency.
