### PR TITLE
Added recursive function to add drupal filter to all h5p string field…

### DIFF
--- a/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_h5p/elmsmedia_h5p.module
+++ b/core/dslmcode/profiles/elmsmedia-7.x-1.x/modules/features/elmsmedia_h5p/elmsmedia_h5p.module
@@ -65,44 +65,44 @@ function elmsmedia_h5p_replicate_ui_access_check_alter(&$access, $type, $entity)
  * Replace H5P's text filter with Drupal's xss filter.
  */
 function elmsmedia_h5p_h5p_filtered_params_alter(&$filtered) {
-  // Get the list of allowed tags
-  $allowed_tags = variable_get('elmsmedia_h5p_allowed_tags', array());
-  $allowed_tags = _elmsmedia_variable_formatter($allowed_tags);
-  drupal_alter('elmsmedia_h5p_allowed_tags', $allowed_tags);
-  // support filtering questions
-  if (isset($filtered->questions)) {
-    // find questions and answers
-    foreach ($filtered->questions as &$choice) {
-      // decode H5P's escaping
-      if (is_string($choice->params->question)) {
-        $choice->params->question = html_entity_decode($choice->params->question);
-        // run it through drupal's xss filter but whitelist our allowed tags
-        $choice->params->question = filter_xss($choice->params->question, $allowed_tags);
+  _elmsmedia_h5p_recursively_add_drupal_filter($filtered);
+}
+
+function _elmsmedia_h5p_recursively_add_drupal_filter(&$fields) {
+  // make sure that we are either an object or an array
+  if (is_object($fields) || is_array($fields)) {
+    // loop through the object or array to attempt to find a text field.
+    // if we find an object or an array then we need to run through this
+    // function again.
+    foreach ($fields as $key => &$field) {
+      if (is_object($field)) {
+        _elmsmedia_h5p_recursively_add_drupal_filter($field);
       }
-      if (isset($choice->params->answers)) {
-        foreach ($choice->params->answers as &$answer) {
-          // decode H5P's escaping
-          $answer->text = html_entity_decode($answer->text);
-          // run it through drupal's xss filter but whitelist our allowed tags
-          $answer->text = filter_xss($answer->text, $allowed_tags);
+      else if (is_array($field)) {
+        _elmsmedia_h5p_recursively_add_drupal_filter($field);
+      }
+      else {
+        // if this is of type string, run it through the drupal filter
+        if (gettype($field) == 'string') {
+          _elmsmedia_h5p_add_drupal_filter($field);
         }
       }
     }
   }
-  else if (isset($filtered->question)) {
-    // decode H5P's escaping
-    $filtered->question = html_entity_decode($filtered->question);
-    // run it through drupal's xss filter but whitelist our allowed tags
-    $filtered->question = filter_xss($filtered->question, $allowed_tags);
-    if (isset($filtered->answers)) {
-      foreach ($filtered->answers as &$answer) {
-        // decode H5P's escaping
-        $answer->text = html_entity_decode($answer->text);
-        // run it through drupal's xss filter but whitelist our allowed tags
-        $answer->text = filter_xss($answer->text, $allowed_tags);
-      }
-    }
-  }
+}
+
+function _elmsmedia_h5p_add_drupal_filter(&$field) {
+  // Get the list of allowed tags
+  $allowed_tags = variable_get('elmsmedia_h5p_allowed_tags', array());
+  $allowed_tags = _elmsmedia_variable_formatter($allowed_tags);
+  drupal_alter('elmsmedia_h5p_allowed_tags', $allowed_tags);
+
+  $value = '';
+  // decode H5P's escaping
+  $value = html_entity_decode($field);
+  // run it through drupal's xss filter but whitelist our allowed tags
+  $value = filter_xss($value, $allowed_tags);
+  $field = $value;
 }
 
 /**


### PR DESCRIPTION
Fixes #2290 

This is a pretty heavy-handed approach.  It forcibly adds the drupal filter to all string-based fields in H5P.  The reason is because there are a ton of different field names that would be difficult to keep track of.  Example. ('intro', 'summary', 'feedback', 'answer', (array) $answers, etc.)

So it's either this method or having to constantly add code to support new content types.
