### PR TITLE
Update to CKEditor custom config

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/ckeditor_custom_config.js
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/ckeditor_custom_config.js
@@ -18,7 +18,7 @@ CKEDITOR.editorConfig = function( config ) {
   // and automatical <p> wrapping
   config.autoParagraph = false;
   // protected source
-  config.protectedSource = [<(!-{2,}|(\S*?)-(\S*?)\s*>)[\s\S]?(</(\S?)-(\S*?)|(-{2,}))>/g];
+  config.protectedSource = [<(!-{2,}|(\S*?)-(\S*?)\s*>)[\s\S]*?(</(\S*?)-(\S*?)|(-{2,}))>/g];
   // config.styleSet is an array of objects that define each style available
   // in the font styles tool in the ckeditor toolbar
   config.disableNativeSpellChecker = false;


### PR DESCRIPTION
Related to issue #2302 and an update to pull request #2305

This adds in a few characters to ensure that original webcomponent support still works.

**Original (#2305) PR message**
Fix for an issue where HTML comments entered into CKEditor Source View would cut off content when switching back to WYSIWYG mode. Includes HTML comments and keeps previous support for WebComponents.