### PR TITLE
Harmony Profile Image adjustment

### DIFF
--- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
+++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
@@ -45,7 +45,7 @@ $links = render($content['links']);
   </div>
   <div class="clearfix">
     <div class="post-left post-user-profile text-center">
-      <a href="#"><?php print $username; ?></a>
+      <a href="#" tabindex="-1"><?php print $username; ?></a>
     </div>
     <div class="post-content post-left-offset">
       <?php print render($content); ?>

--- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
+++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
@@ -45,7 +45,7 @@ $links = render($content['links']);
   </div>
   <div class="clearfix">
     <div class="post-left post-user-profile text-center">
-      <a href="#"><?php print user_load($post->uid)->name; ?></a>
+      <a href="#"><?php print $username; ?></a>
     </div>
     <div class="post-content post-left-offset">
       <?php print render($content); ?>

--- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
+++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
@@ -45,7 +45,7 @@ $links = render($content['links']);
   </div>
   <div class="clearfix">
     <div class="post-left post-user-profile text-center">
-      <?php print $user_profile; ?>
+      <a href="#"><?php print user_load($post->uid)->name; ?></a>
     </div>
     <div class="post-content post-left-offset">
       <?php print render($content); ?>

--- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-profile-image.patch
+++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-profile-image.patch
@@ -1,12 +1,12 @@
 diff --git a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
-index 5d05162cb..50d3be5ec 100644
+index 0244b9dd6..e2092e096 100644
 --- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
 +++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
 @@ -45,7 +45,7 @@
    </div>
    <div class="clearfix">
      <div class="post-left post-user-profile text-center">
--      <a href="#"><?php print user_load($post->uid)->name; ?></a>
+-      <?php print $user_profile; ?>
 +      <a href="#" tabindex="-1"><?php print $username; ?></a>
      </div>
      <div class="post-content post-left-offset">
@@ -16,7 +16,7 @@ index 6a257647c..5999d900b 100644
 --- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/theme.inc
 +++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/theme.inc
 @@ -105,6 +105,7 @@ function template_preprocess_harmony_post(&$variables) {
-
+ 
    // Add in some useful variables.
    $variables['title'] = check_plain($post->title);
 +  $variables['username'] = _elmsln_core_get_user_name('full', $post->uid);

--- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-profile-image.patch
+++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-profile-image.patch
@@ -1,13 +1,25 @@
 diff --git a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
-index 0244b9dd6..5d05162cb 100644
+index 5d05162cb..50d3be5ec 100644
 --- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
 +++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
 @@ -45,7 +45,7 @@
    </div>
    <div class="clearfix">
      <div class="post-left post-user-profile text-center">
--      <?php print $user_profile; ?>
-+      <a href="#"><?php print user_load($post->uid)->name; ?></a>
+-      <a href="#"><?php print user_load($post->uid)->name; ?></a>
++      <a href="#"><?php print $username; ?></a>
      </div>
      <div class="post-content post-left-offset">
        <?php print render($content); ?>
+diff --git a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/theme.inc b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/theme.inc
+index 6a257647c..5999d900b 100644
+--- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/theme.inc
++++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/theme.inc
+@@ -105,6 +105,7 @@ function template_preprocess_harmony_post(&$variables) {
+ 
+   // Add in some useful variables.
+   $variables['title'] = check_plain($post->title);
++  $variables['username'] = _elmsln_core_get_user_name('full', $post->uid);
+   $variables['belongs_to_thread'] = FALSE;
+   if ($thread_id) {
+     $variables['thread_url'] = url("thread/$thread_id");

--- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-profile-image.patch
+++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-profile-image.patch
@@ -1,0 +1,13 @@
+diff --git a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
+index 0244b9dd6..5d05162cb 100644
+--- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
++++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-post.tpl.php
+@@ -45,7 +45,7 @@
+   </div>
+   <div class="clearfix">
+     <div class="post-left post-user-profile text-center">
+-      <?php print $user_profile; ?>
++      <a href="#"><?php print user_load($post->uid)->name; ?></a>
+     </div>
+     <div class="post-content post-left-offset">
+       <?php print render($content); ?>

--- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-profile-image.patch
+++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/harmony-profile-image.patch
@@ -7,7 +7,7 @@ index 5d05162cb..50d3be5ec 100644
    <div class="clearfix">
      <div class="post-left post-user-profile text-center">
 -      <a href="#"><?php print user_load($post->uid)->name; ?></a>
-+      <a href="#"><?php print $username; ?></a>
++      <a href="#" tabindex="-1"><?php print $username; ?></a>
      </div>
      <div class="post-content post-left-offset">
        <?php print render($content); ?>
@@ -16,7 +16,7 @@ index 6a257647c..5999d900b 100644
 --- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/theme.inc
 +++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/theme.inc
 @@ -105,6 +105,7 @@ function template_preprocess_harmony_post(&$variables) {
- 
+
    // Add in some useful variables.
    $variables['title'] = check_plain($post->title);
 +  $variables['username'] = _elmsln_core_get_user_name('full', $post->uid);

--- a/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/theme.inc
+++ b/core/dslmcode/stacks/discuss/sites/all/modules/local_contrib/harmony_core/theme/theme.inc
@@ -105,6 +105,7 @@ function template_preprocess_harmony_post(&$variables) {
 
   // Add in some useful variables.
   $variables['title'] = check_plain($post->title);
+  $variables['username'] = _elmsln_core_get_user_name('full', $post->uid);
   $variables['belongs_to_thread'] = FALSE;
   if ($thread_id) {
     $variables['thread_url'] = url("thread/$thread_id");


### PR DESCRIPTION
This PR contains a tweak to the harmony discussion core which 

Removing the profile image from discussion posts and replacing it with the username of the poster. Default link added to make it match in with local styling.

It definitely a bit hacky, adding a new user_load now I look at it again but if there is a better way of grabbing the username of the poster then please let me know :)