### PR TITLE
removed ‘staff’ specification for add media links. #2371

### DIFF
--- a/core/dslmcode/profiles/mooc-7.x-1.x/themes/mooc_foundation_access/template.php
+++ b/core/dslmcode/profiles/mooc-7.x-1.x/themes/mooc_foundation_access/template.php
@@ -225,7 +225,7 @@ function mooc_foundation_access_menu_tree__menu_elmsln_add($variables) {
   $links = '';
   // make sure nothing shows up if this is the new book
   if (arg(1) != 'lrnapp-book') {
-    if (_cis_connector_role_grouping('staff') && user_access('add item in context')) {
+    if (user_access('add item in context')) {
       $links = _elmsln_core_in_context_list();
       $links = implode("\n", $links);
     }


### PR DESCRIPTION
From what I see, it looks like the permissions should be the same.

Fixes #2371 
