### PR TITLE
docs: fix reversed braces hyperlink syntax

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -38,7 +38,7 @@ Guidelines for bug reports:
 2. **Check if the bug has already been fixed** &mdash; try to reproduce it using the
    repository's latest `master` changes.
 
-3. **Isolate the problem** &mdash; ideally reproducing this issue in our (vagrant environment)[https://github.com/elmsln/elmsln-vagrant]
+3. **Isolate the problem** &mdash; ideally reproducing this issue in our [vagrant environment](https://github.com/elmsln/elmsln-vagrant)
 
 A good bug report shouldn't leave others needing to contact you for more
 information. Please try to be as detailed as possible in your report. What is


### PR DESCRIPTION
"vagrant environment" was kind of a broken link, this fixes it.

![reversed-hyperlink-syntax-broken](https://user-images.githubusercontent.com/952283/40559884-dc40cd6c-601d-11e8-8fdc-481f8a677c11.png)

