### PR TITLE
Media Video functionality moved into web component

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/node/external_video/mediavideo/node--inherit--external-video--mediavideo--poster.tpl.php
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/node/external_video/mediavideo/node--inherit--external-video--mediavideo--poster.tpl.php
@@ -3,6 +3,7 @@
  * For Media Poster, we will add put the poster within the video wrapper to accomidate intrinsic ratio.
  */
 ?>
+<media-video>
 <figure id="node-<?php print $node->nid; ?>" class="mediavideo <?php print $classes; ?>"<?php print $attributes; ?>>
   <?php if (isset($content['field_figurelabel_ref'])): ?>
     <?php print render($content['field_figurelabel_ref'][0]); ?>
@@ -36,3 +37,4 @@
     </div>
   <?php endif; ?>
 </figure>
+</media-video>

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/node/external_video/mediavideo/node--inherit--external-video--mediavideo.tpl.php
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/node/external_video/mediavideo/node--inherit--external-video--mediavideo.tpl.php
@@ -1,3 +1,4 @@
+<media-video>
 <figure id="node-<?php print $node->nid; ?>" class="mediavideo <?php print $classes; ?>"<?php print $attributes; ?>>
   <?php if (isset($content['field_figurelabel_ref'])): ?>
     <?php print render($content['field_figurelabel_ref'][0]); ?>
@@ -32,3 +33,4 @@
     </div>
   <?php endif; ?>
 </figure>
+</media-video>

--- a/core/webcomponents/elements/_build/build.html
+++ b/core/webcomponents/elements/_build/build.html
@@ -47,3 +47,5 @@
 <link rel="import" href="../iron-icons/social-icons.html">
 <link rel="import" href="../iron-icons/places-icons.html">
 <link rel="import" href="../dropdown-select/dropdown-select.html">
+<!-- Display Modes -->
+<link rel="import" href="../media-video/media-video.html"

--- a/core/webcomponents/elements/media-video/media-video.html
+++ b/core/webcomponents/elements/media-video/media-video.html
@@ -1,0 +1,70 @@
+<link rel="import" href="../polymer/polymer.html">
+
+<dom-module id="media-video">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+    <slot></slot>
+  </template>
+
+  <script>
+    Polymer({
+
+      is: 'media-video',
+      behaviors: [],
+      properties: {
+      },
+
+      ready: function() {
+        const videoSrc = this.querySelector('*[data-mediavideo-src]');
+        this.addEventListener('click', (e) => {
+          e.stopPropagation();
+          const target = Polymer.dom(e).localTarget;
+          const videoContainer = this.querySelector('.mediavideo');
+          const videoPoster = this.querySelector('.mediavideo-button-container');
+          const videoSrc = this.querySelector('*[data-mediavideo-src]');
+          videoPoster.classList.toggle('mediavideo-button-display');
+          // Add the is-open tag to the base element.
+          videoContainer.classList.toggle('mediavideo--is-open');
+          if (target.classList.contains('poster--image') ||
+              target.classList.contains('mediavideo-icon')) {
+            // Give the animation enough time to complete.
+            setTimeout(() => {
+              this._startIframeVideo(videoSrc);
+            }, 500);
+          }
+          else {
+            this._stopIframeVideo(videoSrc);
+          }
+        })
+      },
+
+      _startIframeVideo: function (video) {
+        // Start the iframe videos.
+        var videoIframeSrc = video.dataset.mediavideoSrc;
+        // If it's a youtube or vimeo video then add an autoplay attr on the end
+        // of the url.
+        if (videoIframeSrc.indexOf('youtube') >= 0 || videoIframeSrc.indexOf('vimeo') >= 0) {
+          // Find out if we need to fstart the query parameter or add
+          // on to an existing one.
+          if (videoIframeSrc.indexOf('?') >= 0) {
+            videoIframeSrc += '&autoplay=1';
+          }
+          else {
+            videoIframeSrc += '?autoplay=1';
+          }
+        }
+        // Add it to the source attribute to load the video.
+        video.setAttribute('src', videoIframeSrc);
+      },
+
+      _stopIframeVideo: function (video) {
+        video.setAttribute('src', '');
+      },
+
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
I moved the mediavideo display mode functionality from the foundation access script to a web component.  I added it to the `build.html` file located in `webcomponents/elements` — not sure if that's the best way to do it since I don't know if it needs to be loaded globally?

related #2515 