### PR TITLE
corrected replacement patterns for cis tokens.

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/webcomponents/modules/webcomponents_cmstags/webcomponents_cmstags.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/webcomponents/modules/webcomponents_cmstags/webcomponents_cmstags.module
@@ -336,8 +336,8 @@ function _webcomponents_cmstags_process($text, $filter, $format, $langcode, $cac
       // @todo make sure this doesn't match other things
       $regex = '/\[\S*\]/';
       if (preg_match_all($regex, $text, $matches)) {
-        $patterns = array();
-        $media = array();
+        // replacement will consist of patterns and replacements
+        $replacements = array();
         // Have to process multiple matches since more than one player can be on a node.
         foreach ($matches[0] as $key => $match) {
           $tmptoken = str_replace(']', '', str_replace('[', '', $match));
@@ -346,11 +346,16 @@ function _webcomponents_cmstags_process($text, $filter, $format, $langcode, $cac
           $process = TRUE;
           drupal_alter('webcomponents_cmstagsprocess', $process, $tmptoken);
           if ($process) {
-            $patterns[] = $regex;
-            $media[] = '<cms-token token="' . $tmptoken . '"></cms-token>';
+            // add a new replacement
+            $replacements[] = array(
+              'search' => $match,
+              'replace' => '<cms-token token="' . $tmptoken . '"></cms-token>',
+            );
           }
         }
-        $text = preg_replace($patterns, $media, $text, 1);
+        foreach ($replacements as $key => $replacement) {
+          $text = str_replace($replacement['search'], $replacement['replace'], $text);
+        }
       }
       $evaluatedtext = $text;
     }


### PR DESCRIPTION
fixes #2508 

I think there were two reasons it wasn't correctly working.  We were passing along just the standard generic regex `/\[\S*\]/` with each replacement pattern instead of the actual pattern match.  Also, I could not get `preg_replace()` to work correctly with arrays for some reason so I switched it to a foreach loop with `str_replace()`.

# Testing

In a course page, add an "elmsln_" prefixed token such as `[elmsln_section:module_1]`.  Then add a media token such as `[ciscode|rev=1|tool=elmsmedia|item=1|entity_type=node]`
