### PR TITLE
User Block Theme changes

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_lmsless/cis_lmsless.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_lmsless/cis_lmsless.module
@@ -503,9 +503,9 @@ function _cis_lmsless_theme_vars() {
         $vars['user_roles'] = filter_xss(implode(', ', $tmproles));
       }
     }
-    $vars['user_block'] = theme('cis_lmsless_user', $vars);
     // allow other projects to alter these values
     drupal_alter('cis_lmsless_theme_vars', $vars);
+    $vars['user_block'] = theme('cis_lmsless_user', $vars);
   }
   return $vars;
 }


### PR DESCRIPTION
Switched the `theme()` and `drupal_alter()` function calls in `cis_lmsless.module` to allow changing of the user_block *before* it gets processed by the theme.

### Suggested Change
At the moment, the `user_block` is defined before `drupal_alter('cis_lmsless_theme_vars', $vars);` is called which means that devs are not able to make $vars changes take effect in the user flyout menu on the front.

Proposing running the alter hook before the theme is run.
