### PR TITLE
Control over the user flyout login/profile links

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_lmsless/cis_lmsless.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_lmsless/cis_lmsless.module
@@ -469,12 +469,40 @@ function _cis_lmsless_theme_vars() {
     $vars['a11y'] = drupal_render($a11y);
     // set a login link if we don't have a user name
     if ($vars['username'] == t("Anonymous")) {
-      $vars['userlink'] = '<lrnsys-button label="' . t('Log in') . '" href="' . url('user/login') . '" class="account-login" icon="power-settings-new" hover-class="' . $vars['lmsless_classes'][$vars['distro']]['color'] . ' ' . $vars['lmsless_classes'][$vars['distro']]['dark'] . ' white-text"></lrnsys-button>';
+      $vars['userlink'] = array(
+        'label' => t('Log in'),
+        'href'  => url('user/login'),
+        'hover-class' => array(
+          $vars['lmsless_classes'][$vars['distro']]['color'],
+          $vars['lmsless_classes'][$vars['distro']]['dark'],
+          'white-text'
+        ),
+      );
     }
     else {
-      $vars['userlink'] = '<lrnsys-button label="' . t('Log out') . '" href="' . url('user/logout') . '" class="account-logout" icon="power-settings-new" hover-class="' . $vars['lmsless_classes'][$vars['distro']]['color'] . ' ' . $vars['lmsless_classes'][$vars['distro']]['dark'] . ' white-text"></lrnsys-button>';
-
-      $vars['userprofile'] = '<lrnsys-button label="' . t('My profile') . '" href="' . url('user/' . $GLOBALS['user']->uid) . '" icon="account-circle" hover-class="' . $vars['lmsless_classes'][$vars['distro']]['color'] . ' ' . $vars['lmsless_classes'][$vars['distro']]['dark'] . ' white-text"></lrnsys-button>';
+      $vars['userlink'] = array(
+        'label' => t('Log out'),
+        'href'  => url('user/logout'),
+        'class' => 'account-logout',
+        'icon'  => 'power-settings-new',
+        'hover-class' => array(
+          $vars['lmsless_classes'][$vars['distro']]['color'],
+          $vars['lmsless_classes'][$vars['distro']]['dark'],
+          'white-text'
+        ),
+      );
+      
+      $vars['userprofile'] = array(
+        'label' => t('My Profile'),
+        'href'  => url('user/' . $GLOBALS['user']->uid),
+        'class' => array(),
+        'icon'  => 'account-circle',
+        'hover-class' => array(
+          $vars['lmsless_classes'][$vars['distro']]['color'],
+          $vars['lmsless_classes'][$vars['distro']]['dark'],
+          'white-text'
+        ),
+      );
     }
     if (_cis_connector_role_groupings(array('staff','teacher')) || isset($_SESSION['masquerading'])) {
       // account for systems without sections (like authorities)

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_lmsless/cis_lmsless.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_lmsless/cis_lmsless.module
@@ -472,6 +472,7 @@ function _cis_lmsless_theme_vars() {
       $vars['userlink'] = array(
         'label' => t('Log in'),
         'href'  => url('user/login'),
+        'class' => array(),
         'hover-class' => array(
           $vars['lmsless_classes'][$vars['distro']]['color'],
           $vars['lmsless_classes'][$vars['distro']]['dark'],
@@ -483,7 +484,9 @@ function _cis_lmsless_theme_vars() {
       $vars['userlink'] = array(
         'label' => t('Log out'),
         'href'  => url('user/logout'),
-        'class' => 'account-logout',
+        'class' => array(
+          'account-logout'
+        ),
         'icon'  => 'power-settings-new',
         'hover-class' => array(
           $vars['lmsless_classes'][$vars['distro']]['color'],
@@ -491,7 +494,7 @@ function _cis_lmsless_theme_vars() {
           'white-text'
         ),
       );
-      
+
       $vars['userprofile'] = array(
         'label' => t('My Profile'),
         'href'  => url('user/' . $GLOBALS['user']->uid),

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/cis/cis-lmsless-user.tpl.php
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/cis/cis-lmsless-user.tpl.php
@@ -18,7 +18,7 @@
   </li>
   <?php if (!empty($username)) : ?>
   <li>
-    <lrnsys-button label="<?php print $userprofile['label']; ?>" href="<?php print $userprofile['href']; ?>" class="<?php print implode(' ', $userprofile['label']); ?>" icon="<?php print $userprofile['icon']; ?>" hover-class="<?php print implode(' ', $userprofile['label']); ?>"></lrnsys-button>
+    <lrnsys-button label="<?php print $userprofile['label']; ?>" href="<?php print $userprofile['href']; ?>" class="<?php print implode(' ', $userprofile['class']); ?>" icon="<?php print $userprofile['icon']; ?>" hover-class="<?php print implode(' ', $userprofile['hover-class']); ?>"></lrnsys-button>
   </li>
   <?php endif; ?>
   <?php if (isset($user_section) || !empty($masquerade)) : ?>
@@ -66,6 +66,6 @@
   <?php endif; ?>
   <li><div class="divider"></div></li>
   <li>
-    <lrnsys-button label="<?php print $userlink['label']; ?>" href="<?php print $userlink['href']; ?>" class="<?php print implode(' ', $userlink['label']); ?>" icon="<?php print $userlink['icon']; ?>" hover-class="<?php print implode(' ', $userlink['label']); ?>"></lrnsys-button>
+    <lrnsys-button label="<?php print $userlink['label']; ?>" href="<?php print $userlink['href']; ?>" class="<?php print implode(' ', $userlink['class']); ?>" icon="<?php print $userlink['icon']; ?>" hover-class="<?php print implode(' ', $userlink['hover-class']); ?>"></lrnsys-button>
   </li>
 </ul>

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/cis/cis-lmsless-user.tpl.php
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/cis/cis-lmsless-user.tpl.php
@@ -17,7 +17,9 @@
     </div>
   </li>
   <?php if (!empty($username)) : ?>
-  <li><?php print $userprofile; ?></li>
+  <li>
+    <lrnsys-button label="<?php print $userprofile['label']; ?>" href="<?php print $userprofile['href']; ?>" class="<?php print implode(' ', $userprofile['label']); ?>" icon="<?php print $userprofile['icon']; ?>" hover-class="<?php print implode(' ', $userprofile['label']); ?>"></lrnsys-button>
+  </li>
   <?php endif; ?>
   <?php if (isset($user_section) || !empty($masquerade)) : ?>
   <li><div class="divider"></div></li>
@@ -63,5 +65,7 @@
   <li><?php print $masquerade_logout; ?></li>
   <?php endif; ?>
   <li><div class="divider"></div></li>
-  <li><?php print $userlink; ?></li>
+  <li>
+    <lrnsys-button label="<?php print $userlink['label']; ?>" href="<?php print $userlink['href']; ?>" class="<?php print implode(' ', $userlink['label']); ?>" icon="<?php print $userlink['icon']; ?>" hover-class="<?php print implode(' ', $userlink['label']); ?>"></lrnsys-button>
+  </li>
 </ul>


### PR DESCRIPTION
### Description

We've had the need in the past to edit the label and URL of the profile links in the user flyout menu. Thought it might be useful for others as well.

Proposing switching the `$userprofile` and `$userlink` to arrays so that they can be amended easier within `hook_cis_lmsless_theme_vars_alter` without the need of a patch file.

### Commit Message

Switched `$userlink` and `$userprofile` to arrays so they can be changed in `hook_cis_lmsless_theme_vars_alter`