### PR TITLE
User flyout icon fix

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_lmsless/cis_lmsless.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_lmsless/cis_lmsless.module
@@ -473,6 +473,7 @@ function _cis_lmsless_theme_vars() {
         'label' => t('Log in'),
         'href'  => url('user/login'),
         'class' => array(),
+        'icon'  => 'power-settings-new',
         'hover-class' => array(
           $vars['lmsless_classes'][$vars['distro']]['color'],
           $vars['lmsless_classes'][$vars['distro']]['dark'],


### PR DESCRIPTION
Related to #2597 

I forgot to add a default `icon` setting to the user login button. This is just adding it back.

### Commit Message

Added the `power-settings-new` icon to the user login button which had gone AWOL.