### PR TITLE
Updated CKEditor config

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/ckeditor_custom_config.js
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/ckeditor_custom_config.js
@@ -18,7 +18,7 @@ CKEDITOR.editorConfig = function( config ) {
   // and automatical <p> wrapping
   config.autoParagraph = false;
   // protected source
-  config.protectedSource = [/<(!-{2,}|(\S*?)-(\S*?)\s*>)[\s\S]*?(<\/(\S*?)-(\S*?)|(-{2,}))>/g];
+  config.protectedSource = [<(!-{2,}|(\S*?)-(\S*?)\s*>)[\s\S]*?(<\/(\S*?)-(\S*?)|(-{2,}))>/g];
   // config.styleSet is an array of objects that define each style available
   // in the font styles tool in the ckeditor toolbar
   config.disableNativeSpellChecker = false;


### PR DESCRIPTION
Fixes #2600 

Tweaked the `config.protectedSource` setting to properly format HTML comments in CKEditor.