### PR TITLE
"My Profile" button for Anonymous users in flyout menu

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/cis/cis-lmsless-user.tpl.php
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/cis/cis-lmsless-user.tpl.php
@@ -16,7 +16,7 @@
       </div>
     </div>
   </li>
-  <?php if (!empty($username) && $username !== "Anonymous") : ?>
+  <?php if (!empty($username) && $username !== t("Anonymous")) : ?>
   <li>
     <lrnsys-button label="<?php print $userprofile['label']; ?>" href="<?php print $userprofile['href']; ?>" class="<?php print implode(' ', $userprofile['class']); ?>" icon="<?php print $userprofile['icon']; ?>" hover-class="<?php print implode(' ', $userprofile['hover-class']); ?>"></lrnsys-button>
   </li>

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/cis/cis-lmsless-user.tpl.php
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/templates/cis/cis-lmsless-user.tpl.php
@@ -16,7 +16,7 @@
       </div>
     </div>
   </li>
-  <?php if (!empty($username)) : ?>
+  <?php if (!empty($username) && $username !== "Anonymous") : ?>
   <li>
     <lrnsys-button label="<?php print $userprofile['label']; ?>" href="<?php print $userprofile['href']; ?>" class="<?php print implode(' ', $userprofile['class']); ?>" icon="<?php print $userprofile['icon']; ?>" hover-class="<?php print implode(' ', $userprofile['hover-class']); ?>"></lrnsys-button>
   </li>


### PR DESCRIPTION
Currently the "My Profile" link tries to appear for Anonymous users in the flyout menu, despite no data being available.

The `cis-lmsless-template.tpl.php` template is currently checking that `<?php if (!empty($username)) : ?>` however `$username` automatically defaults to "Anonymous" [here](https://github.com/elmsln/elmsln/blob/0.11.x/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_lmsless/cis_lmsless.module#L331) which results in a blank button (as in the screenshot below).

![my profile link](https://user-images.githubusercontent.com/2301874/53164906-40995500-35c9-11e9-8446-fba179122b0d.PNG)

This PR just adds a second to check to make sure the button isn't rendered for Anonymous users.