### PR TITLE
Start scrollspy after user scrolls past navigation block.

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/css/main.css
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/css/main.css
@@ -6594,6 +6594,18 @@ table.sticky-header {
   transform: scale(1.06);
   padding: 0 0 0 .5em;
 }
+/* Add micro interaction for when the scrollspy gets pinned */
+#scrollspy-nav.pinned {
+  animation: scrollspyPinnedAnimation 0.3s;
+}
+@keyframes scrollspyPinnedAnimation {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
 .table-of-contents li {
   padding: 0;
 }

--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/js/main.js
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/js/main.js
@@ -42,12 +42,18 @@ var clipboardjs = require('./components/clipboardjs.js');
    */
   Drupal.behaviors.scrollSpy = {
     attach: function(context, settings) {
-      if (typeof $('#scrollspy-nav').offset() !== typeof undefined) {
+      const scrollSpyNav = $('#scrollspy-nav').offset()
+      if (typeof scrollSpyNav !== typeof undefined) {
         // target data property and convert to scrollspy class addition
         $('h2[data-scrollspy="scrollspy"],h3[data-scrollspy="scrollspy"],h4[data-scrollspy="scrollspy"]').addClass('scrollspy');
         // activate class
         $('.scrollspy').scrollSpy();
-        $('.scrollspy-toc').pushpin({offset: 48, top: $('#scrollspy-nav').offset().top });
+        // the pushpin should start after the user has scrolled past
+        // the navigation block. This is mainly to prevent the scrollspy-toc
+        // from covering up the navigation items below it.
+        const nav = $('#block-mooc-nav-block-mooc-nav-nav')
+        const pushpinStart = Math.ceil(scrollSpyNav.top + nav.height())
+        $('.scrollspy-toc').pushpin({ offset: 48, top: pushpinStart });
       }
     }
   };


### PR DESCRIPTION
fixes #2590

![ezgif-1-19040accdadc](https://user-images.githubusercontent.com/3428964/53302738-88b9b100-382f-11e9-8afb-f4cc498b56d8.gif)

