### PR TITLE
Mooc Nav Block Hook

### DIFF
--- a/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_helper_book_nav/mooc_helper_book_nav.module
+++ b/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_helper_book_nav/mooc_helper_book_nav.module
@@ -301,6 +301,7 @@ function _mooc_helper_book_nav_build($globalnode) {
       }
       $nav_count++;
       $firstlevel = FALSE;
+      drupal_alter('mooc_helper_book_nav', $items, $nav_count);
       $breadcrumbs[] = theme('book_sibling_nav', array('parent' => $parents[$mlid] ,'items' => $items, 'count' => $nav_count));
     }
     $breadcrumbs = array_reverse($breadcrumbs);
@@ -422,4 +423,3 @@ function mooc_helper_book_nav_admin_menu_cache_info() {
   );
   return $caches;
 }
-

--- a/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_nav_block/mooc_nav_block.module
+++ b/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_nav_block/mooc_nav_block.module
@@ -140,7 +140,7 @@ function _mooc_nav_block_mooc_nav_block($node) {
     }
   }
   // @todo may need to hijack the theme suggestion here
-  drupal_alter('mooc_nav_block', $tree);
+  drupal_alter('mooc_nav_mooc_nav_block', $tree);
   $output .= drupal_render($tree);
   $block['subject'] = $nav['label'];
   $block['content'] = $output;

--- a/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_nav_block/mooc_nav_block.module
+++ b/core/dslmcode/profiles/mooc-7.x-1.x/modules/mooc_custom/mooc_nav_block/mooc_nav_block.module
@@ -140,6 +140,7 @@ function _mooc_nav_block_mooc_nav_block($node) {
     }
   }
   // @todo may need to hijack the theme suggestion here
+  drupal_alter('mooc_nav_block', $tree);
   $output .= drupal_render($tree);
   $block['subject'] = $nav['label'];
   $block['content'] = $output;


### PR DESCRIPTION
Added a new hook allowing modules to alter the menu tree used in the book navigation block

#### Description

Added a new hook (`hook_mooc_nav_block_alter`) which allows us to alter the menu tree used to build the navigation block on book pages. This is being used internally to develop a new feature where we need greater control over the links displayed in the sub navigation but could be useful for others. 
