### PR TITLE
Typo fix

### DIFF
--- a/core/dslmcode/profiles/cis-7.x-2.x/modules/custom/cis_helper/cis_helper.admin.inc
+++ b/core/dslmcode/profiles/cis-7.x-2.x/modules/custom/cis_helper/cis_helper.admin.inc
@@ -46,7 +46,7 @@ function cis_helper_admin_settings() {
   // the path for the job to be created on
   $form['cis_build_code'] = array(
     '#type' => 'textfield',
-    '#title' => t('Code authenticed course extra install'),
+    '#title' => t('Code authenticated course extra install'),
     '#default_value' => variable_get('cis_build_code', ''),
     '#description' => t('Additional drush calls when access codes are in use'),
   );


### PR DESCRIPTION
Mini typo fix on `admin/config/system/cis`

![image](https://user-images.githubusercontent.com/2301874/99282550-c0e6fb80-282b-11eb-818d-17b7f845439c.png)
