### PR TITLE
Tincan API Bridge - Allow devs to prevent sends.

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/ulmus/h5p_tincan_bridge/h5p_tincan_bridge.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/ulmus/h5p_tincan_bridge/h5p_tincan_bridge.module
@@ -42,6 +42,7 @@ function h5p_tincan_bridge_view() {
     global $base_url;
 
     $data = json_decode($_POST['statement'], TRUE);
+    $data['send'] = true;
     // Regularize object id with node syntax
     $data['object']['id'] = $base_url . '/node/' . $_POST['nid'];
     $nid = $_POST['nid'];
@@ -53,8 +54,9 @@ function h5p_tincan_bridge_view() {
       $function('h5p_tincan_bridge', $data, $_POST);
     }
 
-
-    tincanapi_send("statements", "POST", $data);
+    if($data['send']){
+      tincanapi_send("statements", "POST", $data);
+    }
   }
 }
 


### PR DESCRIPTION
Allow modules to prevent xAPI posts via the `tincanapi_ajax_data_alter` hook. 

We have a particular use case for this where we prevent certain verbs from actually being sent off to the LRS to cut down on the amount of data being transferred/processed there.

Tweaked it slightly from what we were using in our patch so let me know if it looks fine your end.
