### PR TITLE
Allow entity iframes to display messages.

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/entity_iframe/entity-iframe.tpl.php
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/entity_iframe/entity-iframe.tpl.php
@@ -17,6 +17,11 @@
  * @ingroup themeable
  */
 ?>
+<?php if ($messages): ?>
+  <div class="messages">
+    <?php print $messages; ?>
+  </div>
+<?php endif; ?>
 <div class="entity_iframe_container">
 <?php print $contents; ?>
 </div>

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/entity_iframe/entity_iframe.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/entity_iframe/entity_iframe.module
@@ -77,6 +77,7 @@ function template_preprocess_entity_iframe(&$variables) {
   $variables['language'] = $language;
   $variables['language_rtl'] = ($language->direction == LANGUAGE_RTL);
   $variables['dir'] = $language->direction ? 'rtl' : 'ltr';
+  $variables['messages'] = theme('status_messages');
 }
 
 /**


### PR DESCRIPTION
Fix to allow status messages to be printed within embedded iframe content. Can be useful in some cases, such as embedded webforms, to be able to see if there are any system messages being displayed.