### PR TITLE
Switch section context

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_lmsless/cis_lmsless.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_lmsless/cis_lmsless.module
@@ -571,7 +571,7 @@ function _cis_lmsless_theme_vars() {
         ),
       );
     }
-    if (_cis_connector_role_groupings(array('staff','teacher')) || isset($_SESSION['masquerading'])) {
+    if (_cis_connector_role_groupings(array('staff','teacher')) || user_access('switch section context') || isset($_SESSION['masquerading'])) {
       // account for systems without sections (like authorities)
       if ($section) {
         // ensure they can see the section switcher link
@@ -584,7 +584,7 @@ function _cis_lmsless_theme_vars() {
       if (isset($_SESSION['masquerading'])) {
         $vars['masquerade_logout'] = '<lrnsys-button label="' . t('revert (@name)', array('@name' => $GLOBALS['user']->name)) . '" href="' . url('masquerade/unswitch', array('query' => array('destination' => current_path(), 'token' => drupal_get_token('masquerade/unswitch')))) . '" icon="supervisor-account" hover-class="' . $vars['lmsless_classes'][$vars['distro']]['color'] . ' ' . $vars['lmsless_classes'][$vars['distro']]['dark'] . ' white-text"></lrnsys-button>';
       }
-      else {
+      else if(_cis_connector_role_groupings(array('staff','teacher'))) {
         $tmp = module_invoke('masquerade', 'block_view', 'masquerade');
         $vars['masquerade'] = render($tmp['content']);
       }

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_service_connection/cis_service_connection.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_service_connection/cis_service_connection.module
@@ -246,7 +246,7 @@ function cis_service_connection_block_section_context_changer_form() {
     // ONLY show things they have access to. Only do this after we've got a
     // mechanism for people to allow fellow instructors to access their stuff
     // as an alternate role.
-    $sections = cis_section_all_sections();
+    $sections = cis_section_all_sections(true, true);
     foreach ($sections as $key => $value) {
       $cisSectionData = _cis_connector_transaction('section', 'default', array(), $key);
       if (isset($cisSectionData['host_entity']['field_semester']['und'][0]['value'])) {


### PR DESCRIPTION
Thought I would throw this one up as well while I was at it lol!

This allows anyone who's been given the `switch section context` permission to be able to switch sections (instead of limiting it just to staff/teacher roles), whilst keeping the masquerade feature limited to the original staff/teacher groupings. This allows admin to give certain roles the ability to move between sections without giving them the additional permissions associated with teachers/staff.
