### PR TITLE
Fixing issue which caused an error to be returned from the LRS due to…

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/ulmus/h5p_tincan_bridge/h5p_tincan_bridge.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/ulmus/h5p_tincan_bridge/h5p_tincan_bridge.module
@@ -42,7 +42,7 @@ function h5p_tincan_bridge_view() {
     global $base_url;
 
     $data = json_decode($_POST['statement'], TRUE);
-    $data['send'] = true;
+    $send = true;
     // Regularize object id with node syntax
     $data['object']['id'] = $base_url . '/node/' . $_POST['nid'];
     $nid = $_POST['nid'];
@@ -51,10 +51,10 @@ function h5p_tincan_bridge_view() {
     $hook = 'tincanapi_ajax_data_alter';
     foreach (module_implements($hook) as $module) {
       $function = $module . '_' . $hook;
-      $function('h5p_tincan_bridge', $data, $_POST);
+      $function('h5p_tincan_bridge', $data, $_POST, $send);
     }
 
-    if($data['send']){
+    if($send){
       tincanapi_send("statements", "POST", $data);
     }
   }


### PR DESCRIPTION
Fixing an issue with a previous PR (https://github.com/elmsln/elmsln/pull/2694) for allowing hooks to prevent LRS statements sending.

The send key as it's currently set up will cause the LRS to reject statements because of a rogue `send` key along with the statement data. Replaced it with a boolean variable which allows hooks to cancel a statement sending.

Alternative option would be to `unset` the send key just before sending the statement but thought this was a little cleaner. Let me know if you wanted to go the other route.
