### PR TITLE
Import URI fix for reactive-element

### DIFF
--- a/core/dslmcode/cores/haxcms-1/build/es6/node_modules/lit-element/lit-element.js
+++ b/core/dslmcode/cores/haxcms-1/build/es6/node_modules/lit-element/lit-element.js
@@ -1,4 +1,4 @@
-import{ReactiveElement as e}from"./node_modules/@lit/reactive-element/reactive-element.js";export*from"./node_modules/@lit/reactive-element/reactive-element.js";import{render as t,noChange as l}from"./node_modules/lit-html/lit-html.js";export*from"./node_modules/lit-html/lit-html.js";
+import{ReactiveElement as e}from"../lit/node_modules/@lit/reactive-element/reactive-element.js";export*from"../lit/node_modules/@lit/reactive-element/reactive-element.js";import{render as t,noChange as l}from"./node_modules/lit-html/lit-html.js";export*from"./node_modules/lit-html/lit-html.js";
 /**
  * @license
  * Copyright 2017 Google LLC


### PR DESCRIPTION
I've just updated our development server to v1.2.0 and I think there is an issue with the built version of lit-element. It's trying to load in `reactive-element` but it's using the wrong URI and resulting in a 404 error.

![image](https://user-images.githubusercontent.com/2301874/140511257-ceec0d1a-b8b5-4ff7-86a6-0b657432a4ab.png)

Issue is in this file:

`/var/www/elmsln/core/dslmcode/cores/haxcms-1/build/es6/node_modules/lit-element/lit-element.js`

I've tweaked the import from:

```
import{ReactiveElement as e}from"./node_modules/@lit/reactive-element/reactive-element.js";
export*from"./node_modules/@lit/reactive-element/reactive-element.js";
import{render as t,noChange as l}from"./node_modules/lit-html/lit-html.js";
export*from"./node_modules/lit-html/lit-html.js";
```

to this:

```
import{ReactiveElement as e}from"../lit/node_modules/@lit/reactive-element/reactive-element.js";
export*from"../lit/node_modules/@lit/reactive-element/reactive-element.js";
import{render as t,noChange as l}from"./node_modules/lit-html/lit-html.js";
export*from"./node_modules/lit-html/lit-html.js";
```

Which has fixed the error.