### PR TITLE
Added new hook for adding new options to courses

### DIFF
--- a/core/webcomponents/apps/mooc-content/mooc-content.php
+++ b/core/webcomponents/apps/mooc-content/mooc-content.php
@@ -201,6 +201,7 @@ function _mooc_content_render_options() {
     $content .= '<a tabindex="-1" target="_blank" href="' . base_path() . 'printpdf/' . $node->nid . '" class="accessible-grey-text"><paper-item>' . t('PDF') . '</paper-item></a>';
   }
   $content .='</paper-listbox></paper-menu-button>';
+  drupal_alter('mooc_content_render_options', $content);
   return $content;
 }
 


### PR DESCRIPTION
Added a `hook_mooc_content_render_options_alter` hook to allow us to manually add new options to the course subnav.

Currently we're using this hook to load in a custom region where we can add new blocks containing additional buttons for the course subnav, like this:

```
function modulename_mooc_content_render_options_alter(&$content){
  $blocks = block_get_blocks_by_region('operations');
  $content .= drupal_render($blocks);
}
```

![image](https://user-images.githubusercontent.com/2301874/145388197-c3b36ac1-1a66-40fe-bdc4-41b6e5bb574b.png)
