### PR TITLE
Updating ckeditor_custom_config.js

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/ckeditor_custom_config.js
+++ b/core/dslmcode/shared/drupal-7.x/themes/elmsln_contrib/foundation_access/ckeditor_custom_config.js
@@ -17,8 +17,11 @@ CKEDITOR.editorConfig = function( config ) {
   // this helps ensure there's no conflict with made up elements
   // and automatical <p> wrapping
   config.autoParagraph = false;
-  // protected source
-  config.protectedSource = [<(!-{2,}|(\S*?)-(\S*?)\s*>)[\s\S]*?(<\/(\S*?)-(\S*?)|(-{2,}))>/g];
+  // Enter adds <br /> tags instead of <p>
+  config.enterMode = CKEDITOR.ENTER_BR;
+  // Disable any sort of auto-correction for blocks
+  config.fillEmptyBlocks = false;
+  config.ignoreEmptyParagraph = true;
   // config.styleSet is an array of objects that define each style available
   // in the font styles tool in the ckeditor toolbar
   config.disableNativeSpellChecker = false;
@@ -40,7 +43,7 @@ CKEDITOR.editorConfig = function( config ) {
     // Whether or not you want to highlight matching braces
     matchBrackets: true,
     // Whether or not you want tags to automatically close themselves
-    autoCloseTags: true,
+    autoCloseTags: false,
     // Whether or not you want Brackets to automatically close themselves
     autoCloseBrackets: true,
     // Whether or not to enable search tools, CTRL+F (Find), CTRL+SHIFT+F (Replace), CTRL+SHIFT+R (Replace All), CTRL+G (Find Next), CTRL+SHIFT+G (Find Previous)
@@ -48,13 +51,13 @@ CKEDITOR.editorConfig = function( config ) {
     // Whether or not you wish to enable code folding (requires 'lineNumbers' to be set to 'true')
     enableCodeFolding: true,
     // Whether or not to enable code formatting
-    enableCodeFormatting: true,
+    enableCodeFormatting: false,
     // Whether or not to automatically format code should be done when the editor is loaded
-    autoFormatOnStart: true,
+    autoFormatOnStart: false,
     // Whether or not to automatically format code should be done every time the source view is opened
-    autoFormatOnModeChange: true,
+    autoFormatOnModeChange: false,
     // Whether or not to automatically format code which has just been uncommented
-    autoFormatOnUncomment: true,
+    autoFormatOnUncomment: false,
     // Whether or not to highlight the currently active line
     highlightActiveLine: true,
     // Define the language specific mode 'htmlmixed' for html including (css, xml, javascript), 'application/x-httpd-php' for php mode including html, or 'text/javascript' for using java script only
@@ -77,3 +80,43 @@ CKEDITOR.editorConfig = function( config ) {
     showTabs: true,
   };
 }
+/**
+ * Allow block level elements to be wrapped by inline elements for HAX support.
+ *
+ * An example of this is allowing paragraph tags and custom elements to be wrapped
+ * in a <span> tag which HAX requires
+ */
+CKEDITOR.dtd.span.address = 1;
+CKEDITOR.dtd.span.article = 1;
+CKEDITOR.dtd.span.aside = 1;
+CKEDITOR.dtd.span.blockquote = 1;
+CKEDITOR.dtd.span.canvas = 1;
+CKEDITOR.dtd.span.dd = 1;
+CKEDITOR.dtd.span.div = 1;
+CKEDITOR.dtd.span.dl = 1;
+CKEDITOR.dtd.span.dt = 1;
+CKEDITOR.dtd.span.fieldset = 1;
+CKEDITOR.dtd.span.figcaption = 1;
+CKEDITOR.dtd.span.figure = 1;
+CKEDITOR.dtd.span.footer = 1;
+CKEDITOR.dtd.span.form = 1;
+CKEDITOR.dtd.span.h1 = 1;
+CKEDITOR.dtd.span.h2 = 1;
+CKEDITOR.dtd.span.h3 = 1;
+CKEDITOR.dtd.span.h4 = 1;
+CKEDITOR.dtd.span.h5 = 1;
+CKEDITOR.dtd.span.h6 = 1;
+CKEDITOR.dtd.span.header = 1;
+CKEDITOR.dtd.span.hr = 1;
+CKEDITOR.dtd.span.li = 1;
+CKEDITOR.dtd.span.main = 1;
+CKEDITOR.dtd.span.nav = 1;
+CKEDITOR.dtd.span.noscript = 1;
+CKEDITOR.dtd.span.ol = 1;
+CKEDITOR.dtd.span.p = 1;
+CKEDITOR.dtd.span.pre = 1;
+CKEDITOR.dtd.span.section = 1;
+CKEDITOR.dtd.span.table = 1;
+CKEDITOR.dtd.span.tfoot = 1;
+CKEDITOR.dtd.span.ul = 1;
+CKEDITOR.dtd.span.video = 1;


### PR DESCRIPTION
Updates to CKEditor settings to be more compatible with HAX authoring including allowing inline elements to wrap block elements and switching off auto-formatting

This PR includes fixes which prevents the issues we had with CKEditor adding loads of extra `p` and `span` tags in content and prevents it from doing weird formatting of custom webcomponents.

Related to: https://github.com/elmsln/issues/issues/915
