### PR TITLE
Tweaking cmstags endpoints structure

### DIFF
--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/webcomponents/modules/webcomponents_cmstags/webcomponents_cmstags.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/webcomponents/modules/webcomponents_cmstags/webcomponents_cmstags.module
@@ -167,6 +167,8 @@ function _webcomponents_cmstags_token_render($format) {
     'editEndpoint' => $url,
     'editText' => t('Edit this content'),
   );
+  // allow developers to override the content
+  drupal_alter('webcomponents_cmstags_response', $return);
   // output the response as json
   print drupal_json_output($return);
   exit;

--- a/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/webcomponents/modules/webcomponents_cmstags/webcomponents_cmstags.module
+++ b/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/webcomponents/modules/webcomponents_cmstags/webcomponents_cmstags.module
@@ -98,24 +98,27 @@ function webcomponents_cmstags_page_build(&$page) {
   // Traditional edit forms will have WYSIWYG fields which will unpack
   // these assets and make things angry as a result
   // write the little endPoint shims we use for the other 3 things to decouple
-  $js = 'window.cmsviewsEndPoint="' . base_path() . 'webcomponents/cms-views/' . drupal_get_token('webcomponents_cmstags_views') . '";' . "\n";
-  $js .= 'window.cmsentityEndPoint="' . base_path() . 'webcomponents/cms-entity/' . drupal_get_token('webcomponents_cmstags_entity') . '";' . "\n";
-  $js .= 'window.cmsblockEndPoint="' . base_path() . 'webcomponents/cms-block/' . drupal_get_token('webcomponents_cmstags_block') . '";' . "\n";
-  $js .= 'window.cmstokenEndPoint="' . base_path() . 'webcomponents/cms-token/' . drupal_get_token('webcomponents_cmstags_token') . '/';
+  $endpoints = array(
+    'window.cmsviewsEndPoint' => base_path() . 'webcomponents/cms-views/' . drupal_get_token('webcomponents_cmstags_views'),
+    'window.cmsentityEndPoint' => base_path() . 'webcomponents/cms-entity/' . drupal_get_token('webcomponents_cmstags_entity'),
+    'window.cmsblockEndPoint' => base_path() . 'webcomponents/cms-block/' . drupal_get_token('webcomponents_cmstags_block'),
+    'window.cmstokenEndPoint' => base_path() . 'webcomponents/cms-token/' . drupal_get_token('webcomponents_cmstags_token')
+  );
   // see if there's a node
   if ($node = menu_get_object()) {
     if (isset($node->body['und'][0]['format'])) {
-      $js.= $node->body['und'][0]['format'];
+      $endpoints['window.cmstokenEndPoint'] .= '/' . $node->body['und'][0]['format'];
     }
   }
-  drupal_alter('webcomponents_cmstokenendpoint', $js);
-  $js .= '";' . "\n";
-  $inline = "<script type='text/javascript'>$js</script>";
-  $element = array(
-    '#type' => 'markup',
-    '#markup' => $inline,
+  drupal_alter('webcomponents_cmstokenendpoint', $endpoints);
+  $script = array(
+    '#tag' => 'script',
+    '#attributes' => array('type' => 'text/javascript'),
   );
-  drupal_add_html_head($element, 'webcomponents-cmstags');
+  foreach($endpoints as $key => $val){
+    $script['#value'] .= $key . '="' . $val . '";' . "\n";
+  }
+  drupal_add_html_head($script, 'webcomponents-cmstags');
 }
 
 /**
@@ -318,16 +321,6 @@ function _webcomponents_cmstags_tips($filter, $format, $long = FALSE) {
  * Callback function to perform the content processing.
  */
 function _webcomponents_cmstags_process($text, $filter, $format, $langcode, $cache, $cache_id) {
-  // ensure we only apply this once based on the input format
-  if (!isset($GLOBALS['webcomponentsTokenEndPoint'])) {
-    $GLOBALS['webcomponentsTokenEndPoint'] = TRUE;
-    $js = 'window.cmstokenEndPoint="' . base_path() . 'webcomponents/cms-token/' . drupal_get_token('webcomponents_cmstags_token') . '/' . $filter->format . '";';
-    drupal_add_js($js, array(
-      'type' => 'inline',
-      'group' => JS_LIBRARY,
-      'weight' => -10000)
-    );
-  }
   // see if we need to skip
   if (!isset($GLOBALS['skip_drupal_token'])) {
     // statically cache future calls


### PR DESCRIPTION
Just switching up the cmstags endpoints into an array format so they can be easily overridden in the `webcomponents_cmstokenendpoint_alter` hook.

Also removed the token endpoint being manually added in `_webcomponents_cmstags_process` as this overwrites any hook which edited that endpoint. I've not noticed any issues after removing that my end but let me know if it's important your end.

I can see the webcomponents_cmstokenendpoint_alter hook is being used in core which will need editing but I can't tell if it's required any more: https://github.com/elmsln/elmsln/blob/837cb1bb19c15137ef052e105c7ed5e66eb3c05d/core/dslmcode/shared/drupal-7.x/modules/elmsln_contrib/cis_connector/modules/core/cis_service_connection/cis_service_connection.module#L180